### PR TITLE
add missing variable to lighting link

### DIFF
--- a/_includes/menu_tutorial_application.html
+++ b/_includes/menu_tutorial_application.html
@@ -2,6 +2,6 @@
   <a href="#">{{ page.title }}</a>
 </li>
 <li>
-  <a href="/assets/ophicleide/lightning" target="blank">Lightning Talk &nbsp;
+  <a href="/assets/{{ page.link }}/lightning" target="blank">Lightning Talk &nbsp;
     <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
 </li>


### PR DESCRIPTION
This replaces the hardcoded value with the proper variable from the page
front matter.

closes issue #4