### PR TITLE
clean up the markdown in the kafka question

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -28,4 +28,11 @@ spark-shell
 
 ## How do I connect to Apache Kafka?
 
-You need to add **--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0** when running *spark-shell*, *spark-submit* or to *SPARK_OPTIONS* for S2I, e.g. *oc new-app --template=oshinko-pyspark-build-dc -p GIT_URI=[your source repo] -e SPARK_OPTIONS='--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0'*
+You need to add `--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0`
+when running `spark-shell`, `spark-submit` or to `SPARK_OPTIONS` for S2I. For
+example, to start a new application with these options you could run the
+following:
+
+```
+$ oc new-app --template=oshinko-pyspark-build-dc -p GIT_URI=[your source repo] -e SPARK_OPTIONS='--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0'
+```


### PR DESCRIPTION
This change removes the bold and italics markdown in favor of using the
code literal blocks. Also adds a sentence and moves the example command
into a code block.