### PR TITLE
add the java spark build dc template to resources

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -180,6 +180,170 @@ items:
 
   - apiVersion: v1
     kind: Template
+    labels:
+      application: oshinko-java-spark
+      createdBy: template-oshinko-java-build-dc
+    metadata:
+      annotations:
+        openshift.io/display-name: JavaSpark
+        description: Create a buildconfig, imagestream and deploymentconfig using STI and java spark source hosted in git
+      name: oshinko-java-spark-build-dc
+    objects:
+      - apiVersion: v1
+        kind: ImageStream
+        metadata:
+          name: ${APPLICATION_NAME}
+          labels:
+            app: ${APPLICATION_NAME}
+        spec:
+          dockerImageRepository: ${APPLICATION_NAME}
+          tags:
+            - name: latest
+      - apiVersion: v1
+        kind: BuildConfig
+        metadata:
+          name: ${APPLICATION_NAME}
+          labels:
+            app: ${APPLICATION_NAME}
+        spec:
+          output:
+            to:
+              kind: ImageStreamTag
+              name: ${APPLICATION_NAME}:latest
+          source:
+            git:
+              ref: ${GIT_REF}
+              uri: ${GIT_URI}
+            type: Git
+          strategy:
+            sourceStrategy:
+              type: Source
+              env:
+                - name: APP_FILE
+                  value: ${APP_FILE}
+              forcePull: true
+              from:
+                kind: DockerImage
+                name: radanalyticsio/radanalytics-java-spark
+          triggers:
+            - type: ConfigChange
+            - type: ImageChange
+              imageChange: {}
+            - type: GitHub
+              github:
+                secret: ${APPLICATION_NAME}
+            - type: Generic
+              generic:
+                secret: ${APPLICATION_NAME}
+      - apiVersion: v1
+        kind: DeploymentConfig
+        metadata:
+          labels:
+            app: ${APPLICATION_NAME}
+          name: ${APPLICATION_NAME}
+        spec:
+          replicas: 1
+          selector:
+            deploymentconfig: ${APPLICATION_NAME}
+          strategy:
+            type: Rolling
+          template:
+            metadata:
+              labels:
+                deploymentconfig: ${APPLICATION_NAME}
+                app: ${APPLICATION_NAME}
+            spec:
+              containers:
+                - name: ${APPLICATION_NAME}
+                  image: ${APPLICATION_NAME}
+                  imagePullPolicy: Always
+                  resources: {}
+                  terminationMessagePath: /dev/termination-log
+                  env:
+                    - name: OSHINKO_CLUSTER_NAME
+                      value: ${OSHINKO_CLUSTER_NAME}
+                    - name: APP_ARGS
+                      value: ${APP_ARGS}
+                    - name: SPARK_OPTIONS
+                      value: ${SPARK_OPTIONS}
+                    - name: APP_MAIN_CLASS
+                      value: ${APP_MAIN_CLASS}
+                    - name: OSHINKO_DEL_CLUSTER
+                      value: ${OSHINKO_DEL_CLUSTER}
+                    - name: APP_EXIT
+                      value: ${APP_EXIT}
+                    - name: OSHINKO_NAMED_CONFIG
+                      value: ${OSHINKO_NAMED_CONFIG}
+                    - name: OSHINKO_SPARK_DRIVER_CONFIG
+                      value: ${OSHINKO_SPARK_DRIVER_CONFIG}
+              dnsPolicy: ClusterFirst
+              restartPolicy: Always
+              serviceAccount: oshinko
+          triggers:
+            - type: ConfigChange
+            - type: ImageChange
+              imageChangeParams:
+                automatic: true
+                containerNames:
+                  - ${APPLICATION_NAME}
+                from:
+                  kind: ImageStreamTag
+                  name: ${APPLICATION_NAME}:latest
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${APPLICATION_NAME}
+          labels:
+            app: ${APPLICATION_NAME}
+        spec:
+          ports:
+            - name: 8080-tcp
+              port: 8080
+              protocol: TCP
+              targetPort: 8080
+          selector:
+            deploymentconfig: ${APPLICATION_NAME}
+    parameters:
+      - name: APPLICATION_NAME
+        displayName: Application Name
+        description: The name to use for the BuildConfig, ImageStream and DeploymentConfig components
+        from: pyspark-[a-z0-9]{4}
+        generate: expression
+      - name: GIT_URI
+        displayName: Git Repository URL
+        description: The URL of the repository with your application source code
+        required: true
+      - name: APP_ARGS
+        displayName: Application Arguments
+        description: Command line arguments to pass to the application
+      - name: SPARK_OPTIONS
+        displayName: spark-submit Options
+        description: List of additional options to pass to spark-submit (for exmaple --conf property=value or --package ...). --master and --class are set by the launcher and should not be set here.
+      - name: GIT_REF
+        displayName: Git Reference
+        description: Optional branch, tag or commit
+      - name: OSHINKO_CLUSTER_NAME
+        description: The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.
+      - name: OSHINKO_NAMED_CONFIG
+        description: The name of a stored cluster configuration to use if a cluster is created, default is 'default'.
+      - name: OSHINKO_SPARK_DRIVER_CONFIG
+        description: The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.
+      - name: OSHINKO_DEL_CLUSTER
+        description: If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'
+        value: "true"
+        required: true
+      - name: APP_FILE
+        description: The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.
+      - name: APP_EXIT
+        description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
+        value: "false"
+        required: true
+      - name: APP_MAIN_CLASS
+        description: Application main class for jar-based applications
+        required: true
+
+  - apiVersion: v1
+    kind: Template
     template: oshinko-webui
     metadata:
       name: oshinko-webui

--- a/resources.yaml
+++ b/resources.yaml
@@ -271,7 +271,7 @@ items:
                     - name: OSHINKO_DEL_CLUSTER
                       value: ${OSHINKO_DEL_CLUSTER}
                     - name: APP_EXIT
-                      value: ${APP_EXIT}
+                      value: true
                     - name: OSHINKO_NAMED_CONFIG
                       value: ${OSHINKO_NAMED_CONFIG}
                     - name: OSHINKO_SPARK_DRIVER_CONFIG
@@ -306,41 +306,55 @@ items:
     parameters:
       - name: APPLICATION_NAME
         displayName: Application Name
-        description: The name to use for the BuildConfig, ImageStream and DeploymentConfig components
-        from: pyspark-[a-z0-9]{4}
+        description: |-
+          The name to use for the BuildConfig, ImageStream and
+          DeploymentConfig components
+        from: java-[a-z0-9]{4}
         generate: expression
       - name: GIT_URI
         displayName: Git Repository URL
-        description: The URL of the repository with your application source code
+        description: |-
+          The URL of the repository with your application source code
+        required: true
+      - name: APP_MAIN_CLASS
+        description: Application main class for jar-based applications
         required: true
       - name: APP_ARGS
         displayName: Application Arguments
         description: Command line arguments to pass to the application
       - name: SPARK_OPTIONS
         displayName: spark-submit Options
-        description: List of additional options to pass to spark-submit (for exmaple --conf property=value or --package ...). --master and --class are set by the launcher and should not be set here.
+        description: |-
+          List of additional options to pass to spark-submit (for exmaple
+          --conf property=value or --package ...). --master and --class are
+          set by the launcher and should not be set here.
       - name: GIT_REF
         displayName: Git Reference
         description: Optional branch, tag or commit
       - name: OSHINKO_CLUSTER_NAME
-        description: The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.
+        description: |-
+          The name of the spark cluster to run against. The cluster will be
+          created if it does not exist, and a random cluster name will be
+          chosen if this value is left blank.
       - name: OSHINKO_NAMED_CONFIG
-        description: The name of a stored cluster configuration to use if a cluster is created, default is 'default'.
+        description: |-
+          The name of a stored cluster configuration to use if a cluster is
+          created, default is 'default'.
       - name: OSHINKO_SPARK_DRIVER_CONFIG
-        description: The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.
+        description: |-
+          The name of a configmap to use for the spark configuration of the
+          driver. If this configmap is empty the default spark configuration
+          will be used.
       - name: OSHINKO_DEL_CLUSTER
-        description: If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'
+        description: |-
+          If a cluster is created on-demand, delete the cluster when the
+          application finishes if this option is set to 'true'
         value: "true"
         required: true
       - name: APP_FILE
-        description: The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.
-      - name: APP_EXIT
-        description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
-        value: "false"
-        required: true
-      - name: APP_MAIN_CLASS
-        description: Application main class for jar-based applications
-        required: true
+        description: |-
+          The name of the main JAR file. If this is not specified and there is
+          a single JAR produced by the build, that JAR will be chosen.
 
   - apiVersion: v1
     kind: Template

--- a/resources.yaml
+++ b/resources.yaml
@@ -271,7 +271,7 @@ items:
                     - name: OSHINKO_DEL_CLUSTER
                       value: ${OSHINKO_DEL_CLUSTER}
                     - name: APP_EXIT
-                      value: true
+                      value: "true"
                     - name: OSHINKO_NAMED_CONFIG
                       value: ${OSHINKO_NAMED_CONFIG}
                     - name: OSHINKO_SPARK_DRIVER_CONFIG


### PR DESCRIPTION
This change adds the template for the java s2i builder deployment config
template. It copies the python template and then replaces values with
the upstream java template from the s2i repository.

closes #31 