### PR TITLE
change APP_MAIN_CLASS requirement to false

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -318,7 +318,6 @@ items:
         required: true
       - name: APP_MAIN_CLASS
         description: Application main class for jar-based applications
-        required: false
       - name: APP_ARGS
         displayName: Application Arguments
         description: Command line arguments to pass to the application

--- a/resources.yaml
+++ b/resources.yaml
@@ -318,7 +318,7 @@ items:
         required: true
       - name: APP_MAIN_CLASS
         description: Application main class for jar-based applications
-        required: true
+        required: false
       - name: APP_ARGS
         displayName: Application Arguments
         description: Command line arguments to pass to the application


### PR DESCRIPTION
This change is to allow java jar files that specify their own boot
information. For example, springboot created jars do not work well with
the APP_MAIN_CLASS, but do work well with APP_FILE.