### PR TITLE
fix app exit env variable for java s2i template

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -271,7 +271,7 @@ items:
                     - name: OSHINKO_DEL_CLUSTER
                       value: ${OSHINKO_DEL_CLUSTER}
                     - name: APP_EXIT
-                      value: "true"
+                      value: ${APP_EXIT}
                     - name: OSHINKO_NAMED_CONFIG
                       value: ${OSHINKO_NAMED_CONFIG}
                     - name: OSHINKO_SPARK_DRIVER_CONFIG
@@ -354,6 +354,10 @@ items:
         description: |-
           The name of the main JAR file. If this is not specified and there is
           a single JAR produced by the build, that JAR will be chosen.
+      - name: APP_EXIT
+        description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
+        value: "false"
+        required: true
 
   - apiVersion: v1
     kind: Template


### PR DESCRIPTION
This change replicates the logic that is in the python s2i template
into the java template.