### PR TITLE
add files to the exclude in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,12 @@ exclude:
   - README.md
   - CONTRIBUTING.md
   - Dockerfile
+  - Gemfile
+  - Gemfile.lock
+  - bower.json
   - bower_components/patternfly/tests
+  - bower_components/bootstrap-datepicker
+  - bower_components/eonasdan-bootstrap-datetimepicker
 
 collections:
   projects: {}


### PR DESCRIPTION
This change is to prune some of the non-necssary files from the jekyll
deployment.