### PR TITLE
add menu_items to application markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,12 @@ section, there are a couple steps that need to be completed:
    document.
 4. Add any assets you will need (graphics, files, etc) to your assets
    directory.
-5. Copy the `_templates/lightning` directory into your assets directory. This
+5. If your application includes a lightning talk, copy the
+   `_templates/lightning` directory into your assets directory. This
    directory contains the [reveal.js](https://github.com/hakimel/reveal.js)
-   slide deck template.
+   slide deck template. Also ensure that the `menu_items` front matter
+   contains the `lightning` entry, this will create the proper menu link for
+   the slide deck.
 6. Edit the `index.html` file for the lightning slide deck. (there is
    information in the file on what to provide)
 7. Commit the files to your feature branch and propose a pull request when

--- a/_applications/amqpstreaming.md
+++ b/_applications/amqpstreaming.md
@@ -4,6 +4,7 @@ link: amqpstreaming
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   This demo shows how it's possible to integrate AMQP based products with Apache Spark Streaming. It uses the AMQP Spark Streaming connector, which is able to get messages from an AMQP source and pushing them to the Spark engine as micro batches for real time analytics
 project_links:

--- a/_applications/fabric8-maven-plugin.md
+++ b/_applications/fabric8-maven-plugin.md
@@ -4,6 +4,7 @@ link: fabric8-maven-plugin
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   This demo shows how to use the Fabric8 Maven Plugin to deploy a Spark cluster on Openshift.
   

--- a/_applications/grafzahl.md
+++ b/_applications/grafzahl.md
@@ -4,6 +4,7 @@ link: grafzahl
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   Graf Zahl is a demonstration application using Spark's Structured
   Streaming feature to read data from an Apache Kafka topic. It

--- a/_applications/jgrafzahl.md
+++ b/_applications/jgrafzahl.md
@@ -4,6 +4,7 @@ link: jgrafzahl
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   jGraf Zahl is a Java implementation of the Graf Zahl application.
   It is a demonstration of using Spark's Structured

--- a/_applications/ophicleide.md
+++ b/_applications/ophicleide.md
@@ -4,6 +4,7 @@ link: ophicleide
 weight: 0
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
  Ophicleide is an application that can ingest text data from URL sources and
  process it with Word2vec to create data models. These resulting models can

--- a/_applications/pyspark_hdfs_notebook.md
+++ b/_applications/pyspark_hdfs_notebook.md
@@ -4,6 +4,7 @@ link: pyspark_hdfs_notebook
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   This is a very simple Jupyter notebook application which runs on OpenShift. It shows how to read a file from a remote HDFS filesystem with PySpark.
 project_links:

--- a/_applications/s3-source-example.md
+++ b/_applications/s3-source-example.md
@@ -4,6 +4,7 @@ link: s3-source-example
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   This is an example of how to connect your application to data in S3.
 project_links:

--- a/_applications/spring_sparkpi.md
+++ b/_applications/spring_sparkpi.md
@@ -4,6 +4,7 @@ link: spring_sparkpi
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   This source-to-image Java application combines the Apache Spark Pi
   estimation example with the popular Spring Boot framework. It provides an

--- a/_applications/var.md
+++ b/_applications/var.md
@@ -4,6 +4,7 @@ link: var
 weight: 1
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
  The value-at-risk notebook is a simple example of how to run Jupyter notebooks on OpenShift, Monte Carlo simulations in Spark, and how to interactively explore data to find better ways to model it.
 project_links:

--- a/_includes/menu_tutorial_application.html
+++ b/_includes/menu_tutorial_application.html
@@ -1,10 +1,14 @@
 <li class="active">
   <a href="#">{{ page.title }}</a>
 </li>
+
+{% if page.menu_items contains 'lightning' %}
 <li>
   <a href="/assets/{{ page.link }}/lightning" target="blank">Lightning Talk &nbsp;
     <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
 </li>
+{% endif %}
+
 <li>
   <a href="/tutorials">Back to tutorials</a>
 </li>

--- a/_templates/example_application.md
+++ b/_templates/example_application.md
@@ -4,6 +4,7 @@ link: example_application
 weight: 100
 layout: application
 menu_template: menu_tutorial_application.html
+menu_items: lightning
 description: |-
   Put your description here, this text will be rendered on the "Tutorials"
   page under your application's title.
@@ -34,6 +35,8 @@ documentation are: `title`, `link`, `description` and `project_links`.
   describe your application
 * `project_links` is an array of links that will be displayed on the tutorials
   page with your application, add any links to your source material here
+* `menu_items` is an array that aids in the construction of the menu links
+  on the application page. The current options are: `lightning`.
 
 If you need to add graphics or other assets to your application page, please
 make a directory under the top level `assets` directory. This new directory


### PR DESCRIPTION
This change adds the menu_items front matter to the applications
markdown. The menu_items allows for custom definition of which links
should appear in the tutorial application menu. Currently the only
supported option in `lightning`, for the lightning talk slide deck. This
change also adds some documentation about how menu_items works.