### PR TITLE
Add labels

### DIFF
--- a/_applications/amqpstreaming.md
+++ b/_applications/amqpstreaming.md
@@ -2,6 +2,9 @@
 title: AMQP - Spark Streaming
 link: amqpstreaming
 weight: 100
+labels:
+- Scala
+- ActiveMQ
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/fabric8-maven-plugin.md
+++ b/_applications/fabric8-maven-plugin.md
@@ -2,6 +2,9 @@
 title: Fabric8 Maven Plugin Example
 link: fabric8-maven-plugin
 weight: 100
+labels:
+- Java
+- Kafka
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/grafzahl.md
+++ b/_applications/grafzahl.md
@@ -2,6 +2,10 @@
 title: Graf Zahl
 link: grafzahl
 weight: 100
+labels:
+- Python
+- Kafka
+- S2I
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/jgrafzahl.md
+++ b/_applications/jgrafzahl.md
@@ -2,6 +2,10 @@
 title: jGraf Zahl
 link: jgrafzahl
 weight: 100
+labels:
+- Java
+- Kafka
+- S2I
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/ophicleide.md
+++ b/_applications/ophicleide.md
@@ -2,6 +2,9 @@
 title: Ophicleide
 link: ophicleide
 weight: 0
+labels:
+- Python
+- MongoDB
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/pyspark_hdfs_notebook.md
+++ b/_applications/pyspark_hdfs_notebook.md
@@ -2,6 +2,10 @@
 title: PySpark HDFS Notebook
 link: pyspark_hdfs_notebook
 weight: 100
+labels:
+- Python
+- HDFS
+- Jupyter
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/s3-source-example.md
+++ b/_applications/s3-source-example.md
@@ -2,6 +2,10 @@
 title: S3 Source Example
 link: s3-source-example
 weight: 100
+labels:
+- Python
+- S3
+- Jupyter
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/spring_sparkpi.md
+++ b/_applications/spring_sparkpi.md
@@ -2,6 +2,9 @@
 title: Spring Boot SparkPi
 link: spring_sparkpi
 weight: 100
+labels:
+- Java
+- S2I
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_applications/var.md
+++ b/_applications/var.md
@@ -2,6 +2,9 @@
 title: Value-at-risk notebook
 link: var
 weight: 1
+labels:
+- Python
+- Jupyter
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning

--- a/_projects/openshift-spark.md
+++ b/_projects/openshift-spark.md
@@ -1,5 +1,7 @@
 ---
 title: OpenShift Spark
+labels:
+- Infrastructure
 ---
 
 The openshift-spark repository contains all the files necessary to create

--- a/_projects/oshinko.md
+++ b/_projects/oshinko.md
@@ -1,5 +1,7 @@
 ---
 title: Oshinko
+labels:
+- Infrastructure
 ---
 
 Oshinko is a top level namespace that covers several individual projects

--- a/_projects/scorpion-stare.md
+++ b/_projects/scorpion-stare.md
@@ -1,5 +1,7 @@
 ---
 title: Scorpion Stare
+labels:
+- Spark Extension
 ---
 
 This project provides Apache Spark backend plugin-ins for awareness of

--- a/_projects/silex.md
+++ b/_projects/silex.md
@@ -1,5 +1,7 @@
 ---
 title: Silex
+labels:
+- Spark Extension
 ---
 
 This is a library of reusable code for Spark applications, factored out of

--- a/_projects/spark-amqp-connector.md
+++ b/_projects/spark-amqp-connector.md
@@ -1,5 +1,7 @@
 ---
 title: Spark AMQP Connector
+labels:
+- Spark Extension
 ---
 
 This project provides an AMQP (Advanced Message Queuing Protocol) connector

--- a/_templates/example_application.md
+++ b/_templates/example_application.md
@@ -2,6 +2,8 @@
 title: Example Application
 link: example_application
 weight: 100
+labels:
+- Language
 layout: application
 menu_template: menu_tutorial_application.html
 menu_items: lightning
@@ -37,6 +39,8 @@ documentation are: `title`, `link`, `description` and `project_links`.
   page with your application, add any links to your source material here
 * `menu_items` is an array that aids in the construction of the menu links
   on the application page. The current options are: `lightning`.
+* `labels` is an array of strings that describe the primary technologies in
+  use within the application (eg Python, ActiveMQ, S3).
 
 If you need to add graphics or other assets to your application page, please
 make a directory under the top level `assets` directory. This new directory

--- a/projects.html
+++ b/projects.html
@@ -24,7 +24,12 @@ menu_entry: Projects
   {% for project in site.projects %}
   <div class="row">
     <div class="col-lg-10 col-lg-offset-1">
-      <h2>{{ project.title }}</h2>
+      <h2>
+        {{ project.title }}
+        {% for label in project.labels %}
+        <span class="badge">{{ label }}</span>
+        {% endfor %}
+      </h2>
       {{ project.content }}
     </div>
   </div>

--- a/tutorials.md
+++ b/tutorials.md
@@ -14,7 +14,12 @@ your own settings.
 
 {% assign sorted_applications = site.applications | sort: 'weight' %}
 {% for app in sorted_applications %}
-<h2><a href="/applications/{{ app.link }}">{{ app.title }}</a></h2>
+<h2>
+<a href="/applications/{{ app.link }}">{{ app.title }}</a>
+{% for label in app.labels %}
+<span class="badge">{{ label }}</span>
+{% endfor %}
+</h2>
 
 <p>
 {{ app.description }}


### PR DESCRIPTION
This change adds labels for the tutorial applications and projects. The labels are implemented as front matter for each markdown document. The labels are displayed as badges next to the titles in the tutorials and projects pages.

this closes #48 