### PR TITLE
remove required main class for scala s2i

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -530,7 +530,6 @@ items:
         required: true
       - name: APP_MAIN_CLASS
         description: Application main class for jar-based applications
-        required: true
       - name: APP_ARGS
         displayName: Application Arguments
         description: Command line arguments to pass to the application


### PR DESCRIPTION
There are cases where the main class is not required, this should not
prevent a user from creating a spark s2i applicaiton.