### PR TITLE
updated VaR tutorial

### DIFF
--- a/_applications/var.md
+++ b/_applications/var.md
@@ -11,7 +11,7 @@ menu_items: lightning
 description: |-
  The value-at-risk notebook is a simple example of how to run Jupyter notebooks on OpenShift, Monte Carlo simulations in Spark, and how to interactively explore data to find better ways to model it.
 project_links:
-- https://github.com/willb/var-notebook
+- https://github.com/radanalyticsio/workshop-notebook
 ---
 
 <h1 id="introduction">Introduction</h1>
@@ -29,94 +29,37 @@ sophisticated manner.
 <h1 id="architecture">Architecture</h1>
 
 The driver for the value-at-risk application is a
-[Jupyter](http://jupyter.org/) notebook. This notebook connects to a Spark
-cluster and schedules jobs to perform simulations.
+[Jupyter](http://jupyter.org/) notebook.  A Jupyter notebook is an interactive compute 
+environment that interleaves documentation, code examples, and graphical output.  This 
+particular notebook uses Spark to orchestrate simulations of the stock market.
 
-<h1 id="installation">Installation</h1>
+<h1 id="installation">Basic installation</h1>
 
-Installing the value-at-risk notebook is straightforward; you simply need to
-create an OpenShift project, deploy a Spark cluster in that project, and
-install and run the notebook image.
+We'll start by using the notebook the way a data scientist might for initial
+experimentation, with a single Spark executor embedded within the application. Running
+a notebook on OpenShift provides a lot of advantages even if we aren't using scale-out
+compute:
 
-## Prerequisites
+1. if we have a project accessible from a public cloud, we can work on it from
+anywhere, with any device;
+2. we can easily share our work with colleagues; and
+3. our results will be easily reproducible, since repeatable deployments mean they
+won't depend on any details of our environment.
 
-The easiest way to get a Spark cluster going in your OpenShift project is to
-use [the OpenShift template](https://radanalytics.io/get-started#quickstart-with-oshinko) 
-provided on the "Getting Started page".  This provides a streamlined installation for
-the Oshinko cluster manager into your project. Oshinko is a service to manage
-Spark clusters for OpenShift projects.
+## Install and run the notebook
 
-We'll need to use a special Spark worker image for this application. This
-worker image has a small amount of historical stock return data stored in its
-filesystem. For a real application, you'd want to get data from persistent
-storage, from a database, or from an object store service. For a demo, though,
-it's much easier to package up a small amount of data where each worker can get
-it.
+Installing our notebook is very simple:  we just need to create an OpenShift project and install and run the notebook application.  Make sure you're logged in to OpenShift and have selected the right project, and then execute the following two commands:
 
-In order to get this special Spark worker image, we'll need to pass a special option 
-to the Oshinko template when we install it in our project.  Set the `OSHINKO_CLUSTER_IMAGE` 
-variable to `radanalyticsio/workshop-notebook`.  This image is based on the default cluster
-image, but it also includes our historical stock data.
+`oc new-app radanalyticsio/workshop-notebook -e JUPYTER_NOTEBOOK_PASSWORD=developer`
 
-## Setting up a cluster
+`oc expose svc/workshop-notebook`
 
-From the OpenShift developer console, visit the Oshinko web interface. Use the
-interface to create a new cluster, and take note of what you've called this
-cluster. The rest of this documentation will assume that your cluster is named
-`sparky`, and so your master URL is `spark://sparky:7077`.  Since this application's
-compute and memory demands are extremely light, you'll get the best performance from a
-single-worker "cluster," although you can add more nodes if you want to run many
-simulations.
-
-## Adding the notebook application
-
-The next step is to add the notebook application. From the OpenShift developer
-console, select "Add to Project" and then "Deploy Image." We'll be deploying an
-image with a particular name, so select "Image Name" and then enter
-`radanalyticsio/workshop-notebook`.
-
-Once the `var-notebook` service is visible within the developer console, select
-"Create Route" and create a public route to the `var-notebook` service,
-targeting port 8888. The public route you create will depend on your DNS
-configuration, but you can use the [xip.io
-service](https://access.redhat.com/solutions/2141701) for development and
-testing.  If you just select "Create Route," OpenShift will do the right 
-
-<h1 id="usage">Launching and Using the Notebook</h1>
-
-Verify that the `var-notebook` service is running and that your Spark cluster
-is running by looking at the developer console. Once each is up and functional,
-you can use the notebook by visiting the route you defined earlier in your
-browser.
+Check the OpenShift web console.  Once the notebook application is running, click on its route.  Jupyter will ask you to log in; use `developer` for a password (or the password you specified if you used a different one when you ran `oc new-app`).  You'll be presented with a list of notebooks that are installed in the workshop-notebook image.  The one we're interested in is `var.ipynb`, so click on it.  (There are some other files in this image:  `pyspark.ipynb` is an introduction to Apache Spark, `ml-basics.ipynb` introduces some basic machine learning techniques, and `var-demo.ipynb` is similar to `var.ipynb`, but with less explanatory text, to make it more suitable for a live demo.)
 
 Interacting with the Jupyter notebook is very simple. Select a cell with Python
-code and execute it by pressing the "run cell" button in the toolbar. Before
-you get started, you'll need to make sure you're able to connect to your Spark
-cluster: in the very first code cell, find the line that looks like this:
+code and then execute it, either by pressing the "run cell" button in the toolbar, or by pressing &#8679;&#8629;.  You can edit the code in the notebook cells and re-run them, and results from cells you've already run will be available to new cells. The notebook interface provides a great way to experiment with new techniques. Try it out!
 
-`spark = SparkSession.builder.master("spark://sparky:7077").getOrCreate()`
-
-and replace `sparky` with whatever name you chose for your Spark cluster.
-
-You can edit the code in the notebook cells and re-run them, and results from
-cells you've already run will be available to new cells. The notebook interface
-provides a great way to experiment with new techniques. Try it out!
-
-<h1 id="expansion">Extending the application</h1>
-
-There are lots of ways to extend this application.  Here are a few suggestions:
-
-1. Using the Seaborn library's `distplot` function and models from SciPy, find
-a distribution that is a better fit for the stock returns data.
-2. Use this distribution to fit models to each ticker symbol and develop a new
-simulate method to sample from these distributions rather than from normal
-distributions. Compare the results of this simulation to the results of the
-simulation 
-3. ★ Implement a goodness-of-fit test of your choice. 
-4. ★ Identify some additional distributions to use for modeling security
-returns that don't work well with the distribution you identified above. Build
-a more sophisticated simulation that chooses one of several possible
-distributions for each security to find the best fit.
+Once you've worked through the whole notebook, consider trying out the self-guided exercises at the end of the notebook.  If you want to run your own Jupyter notebooks in OpenShift, consider extending the [base-notebook](https://github.com/radanalyticsio/base-notebook) image.
 
 <h1 id="videos">Videos</h1>
 
@@ -125,3 +68,44 @@ following video:
 
 <iframe src="https://player.vimeo.com/video/194528216" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 <p><a href="https://vimeo.com/194528216">Value-at-risk notebook demo in OpenShift</a>.</p>
+
+# Appendix: running against a cluster
+
+While it certainly isn't necessary for the amount of data we're processing in this project, you could also run your simulations against a Spark cluster.  We'll show you how to do that now.
+
+## Clustered installation prerequisites
+
+The easiest way to get a Spark cluster going in your OpenShift project is to use [the
+OpenShift template](https://radanalytics.io/get-started#quickstart-with-oshinko)
+provided on the "Getting Started page". This provides a streamlined installation for
+the Oshinko service, which manages Spark clusters in OpenShift projects.
+
+We'll need to use a special Spark worker image for this application. This worker image
+has a small amount of historical stock return data stored in its filesystem. For a real
+application, you'd want to get data from persistent storage, from a database, or from
+an object store service. For a self-contained tutorial demo, though, it's much easier
+to package up a small amount of data where each worker can get it.
+
+In order to get this special Spark worker image, we'll need to pass a special option 
+to the Oshinko template when we install it in our project.  Set the `OSHINKO_CLUSTER_IMAGE` variable to `radanalyticsio/workshop-notebook:worker`.  This image is based on the default `radanalyticsio/openshift-spark` image, but it also includes our historical stock data.
+
+## Setting up a cluster
+
+From the OpenShift developer console, visit the Oshinko web interface. Use the
+interface to create a new cluster, and take note of what you've called this
+cluster. The rest of this documentation will assume that your cluster is named
+`sparky`, and so your master URL is `spark://sparky:7077`.  Since this application's
+compute and memory demands are extremely light, you'll get the best performance from a
+single-worker cluster, although you can add more nodes if you want to run many
+simulations.
+
+## Adding the notebook application
+
+If you haven't already started the notebook application, follow the instructions in the [basic installation](#installation) section to add the notebook application to your project.  If you have started the notebook application, make sure to restart your Jupyter kernel (in the "Kernel" menu) before proceeding.
+
+In order to run against a cluster, you'll need to make a minor change to the notebook text: in the very first code cell, find the line that looks like this:
+
+`spark = SparkSession.builder.master("local[1]").getOrCreate()`
+
+and replace `local[1]` with `spark://sparky:7077` (or, if you chose something other than `sparky`, whatever name you chose for your Spark cluster).  From here, you should be able to proceed as before.
+

--- a/_applications/var.md
+++ b/_applications/var.md
@@ -29,16 +29,15 @@ sophisticated manner.
 <h1 id="architecture">Architecture</h1>
 
 The driver for the value-at-risk application is a
-[Jupyter](http://jupyter.org/) notebook.  A Jupyter notebook is an interactive compute 
-environment that interleaves documentation, code examples, and graphical output.  This 
-particular notebook uses Spark to orchestrate simulations of the stock market.
+[Jupyter](http://jupyter.org/) notebook. A Jupyter notebook is an interactive
+compute environment that interleaves documentation, code examples, and
+graphical output. This particular notebook uses Spark to orchestrate
+simulations of the stock market.
 
-<h1 id="installation">Basic installation</h1>
-
-We'll start by using the notebook the way a data scientist might for initial
-experimentation, with a single Spark executor embedded within the application. Running
-a notebook on OpenShift provides a lot of advantages even if we aren't using scale-out
-compute:
+We'll use the notebook the way a data scientist might for initial
+experimentation, with a single Spark executor embedded within the application.
+Running a notebook on OpenShift provides a lot of advantages even if we aren't
+using scale-out compute:
 
 1. if we have a project accessible from a public cloud, we can work on it from
 anywhere, with any device;
@@ -46,7 +45,7 @@ anywhere, with any device;
 3. our results will be easily reproducible, since repeatable deployments mean they
 won't depend on any details of our environment.
 
-## Install and run the notebook
+<h1 id="installation">Install and run the notebook</h1>
 
 Installing our notebook is very simple:  we just need to create an OpenShift project and install and run the notebook application.  Make sure you're logged in to OpenShift and have selected the right project, and then execute the following two commands:
 
@@ -54,12 +53,19 @@ Installing our notebook is very simple:  we just need to create an OpenShift pro
 
 `oc expose svc/workshop-notebook`
 
-Check the OpenShift web console.  Once the notebook application is running, click on its route.  Jupyter will ask you to log in; use `developer` for a password (or the password you specified if you used a different one when you ran `oc new-app`).  You'll be presented with a list of notebooks that are installed in the workshop-notebook image.  The one we're interested in is `var.ipynb`, so click on it.  (There are some other files in this image:  `pyspark.ipynb` is an introduction to Apache Spark, `ml-basics.ipynb` introduces some basic machine learning techniques, and `var-demo.ipynb` is similar to `var.ipynb`, but with less explanatory text, to make it more suitable for a live demo.)
+Check the OpenShift web console.  Once the notebook application is running, click on its route.  Jupyter will ask you to log in; use `developer` for a password (or the password you specified if you used a different one when you ran `oc new-app`).  You'll be presented with a list of notebooks that are installed in the workshop-notebook image.  The one we're interested in is `var.ipynb`, so click on it.  (There are some other files in this image:  `pyspark.ipynb` is an introduction to Apache Spark and `ml-basics.ipynb` introduces some basic machine learning techniques.)
 
 Interacting with the Jupyter notebook is very simple. Select a cell with Python
-code and then execute it, either by pressing the "run cell" button in the toolbar, or by pressing &#8679;&#8629;.  You can edit the code in the notebook cells and re-run them, and results from cells you've already run will be available to new cells. The notebook interface provides a great way to experiment with new techniques. Try it out!
+code and then execute it, either by pressing the "run cell" button in the
+toolbar or by pressing shift + enter. You can edit the code in the notebook
+cells and re-run them, and results from cells you've already run will be
+available to new cells. The notebook interface provides a great way to
+experiment with new techniques. Try it out!
 
-Once you've worked through the whole notebook, consider trying out the self-guided exercises at the end of the notebook.  If you want to run your own Jupyter notebooks in OpenShift, consider extending the [base-notebook](https://github.com/radanalyticsio/base-notebook) image.
+Once you've worked through the whole notebook, consider trying out the
+self-guided exercises at the end of the notebook. If you want to run your own
+Jupyter notebooks in OpenShift, consider extending the
+[base-notebook](https://github.com/radanalyticsio/base-notebook) image.
 
 <h1 id="videos">Videos</h1>
 
@@ -68,44 +74,4 @@ following video:
 
 <iframe src="https://player.vimeo.com/video/194528216" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 <p><a href="https://vimeo.com/194528216">Value-at-risk notebook demo in OpenShift</a>.</p>
-
-# Appendix: running against a cluster
-
-While it certainly isn't necessary for the amount of data we're processing in this project, you could also run your simulations against a Spark cluster.  We'll show you how to do that now.
-
-## Clustered installation prerequisites
-
-The easiest way to get a Spark cluster going in your OpenShift project is to use [the
-OpenShift template](https://radanalytics.io/get-started#quickstart-with-oshinko)
-provided on the "Getting Started page". This provides a streamlined installation for
-the Oshinko service, which manages Spark clusters in OpenShift projects.
-
-We'll need to use a special Spark worker image for this application. This worker image
-has a small amount of historical stock return data stored in its filesystem. For a real
-application, you'd want to get data from persistent storage, from a database, or from
-an object store service. For a self-contained tutorial demo, though, it's much easier
-to package up a small amount of data where each worker can get it.
-
-In order to get this special Spark worker image, we'll need to pass a special option 
-to the Oshinko template when we install it in our project.  Set the `OSHINKO_CLUSTER_IMAGE` variable to `radanalyticsio/workshop-notebook:worker`.  This image is based on the default `radanalyticsio/openshift-spark` image, but it also includes our historical stock data.
-
-## Setting up a cluster
-
-From the OpenShift developer console, visit the Oshinko web interface. Use the
-interface to create a new cluster, and take note of what you've called this
-cluster. The rest of this documentation will assume that your cluster is named
-`sparky`, and so your master URL is `spark://sparky:7077`.  Since this application's
-compute and memory demands are extremely light, you'll get the best performance from a
-single-worker cluster, although you can add more nodes if you want to run many
-simulations.
-
-## Adding the notebook application
-
-If you haven't already started the notebook application, follow the instructions in the [basic installation](#installation) section to add the notebook application to your project.  If you have started the notebook application, make sure to restart your Jupyter kernel (in the "Kernel" menu) before proceeding.
-
-In order to run against a cluster, you'll need to make a minor change to the notebook text: in the very first code cell, find the line that looks like this:
-
-`spark = SparkSession.builder.master("local[1]").getOrCreate()`
-
-and replace `local[1]` with `spark://sparky:7077` (or, if you chose something other than `sparky`, whatever name you chose for your Spark cluster).  From here, you should be able to proceed as before.
 

--- a/_applications/var.md
+++ b/_applications/var.md
@@ -41,11 +41,10 @@ install and run the notebook image.
 ## Prerequisites
 
 The easiest way to get a Spark cluster going in your OpenShift project is to
-use [`oshinko-deploy.sh`][odsh]. This provides a streamlined installation for
+use [the OpenShift template](https://radanalytics.io/get-started#quickstart-with-oshinko) 
+provided on the "Getting Started page".  This provides a streamlined installation for
 the Oshinko cluster manager into your project. Oshinko is a service to manage
 Spark clusters for OpenShift projects.
-
-[odsh]: https://github.com/radanalyticsio/oshinko-webui/blob/master/tools/oshinko-deploy.sh
 
 We'll need to use a special Spark worker image for this application. This
 worker image has a small amount of historical stock return data stored in its
@@ -54,31 +53,34 @@ storage, from a database, or from an object store service. For a demo, though,
 it's much easier to package up a small amount of data where each worker can get
 it.
 
-In order to get this special Spark worker image, we'll use the `-s` flag to
-`oshinko-deploy.sh`:
-
-`oshinko-deploy.sh -s willb/var-spark-worker`
+In order to get this special Spark worker image, we'll need to pass a special option 
+to the Oshinko template when we install it in our project.  Set the `OSHINKO_CLUSTER_IMAGE` 
+variable to `radanalyticsio/workshop-notebook`.  This image is based on the default cluster
+image, but it also includes our historical stock data.
 
 ## Setting up a cluster
 
 From the OpenShift developer console, visit the Oshinko web interface. Use the
 interface to create a new cluster, and take note of what you've called this
 cluster. The rest of this documentation will assume that your cluster is named
-`sparky`, and so your master URL is `spark://sparky:7077`.
+`sparky`, and so your master URL is `spark://sparky:7077`.  Since this application's
+compute and memory demands are extremely light, you'll get the best performance from a
+single-worker "cluster," although you can add more nodes if you want to run many
+simulations.
 
 ## Adding the notebook application
 
 The next step is to add the notebook application. From the OpenShift developer
 console, select "Add to Project" and then "Deploy Image." We'll be deploying an
 image with a particular name, so select "Image Name" and then enter
-`willb/var-notebook:var35`.
+`radanalyticsio/workshop-notebook`.
 
 Once the `var-notebook` service is visible within the developer console, select
 "Create Route" and create a public route to the `var-notebook` service,
 targeting port 8888. The public route you create will depend on your DNS
 configuration, but you can use the [xip.io
 service](https://access.redhat.com/solutions/2141701) for development and
-testing.
+testing.  If you just select "Create Route," OpenShift will do the right 
 
 <h1 id="usage">Launching and Using the Notebook</h1>
 


### PR DESCRIPTION
This removes some of the old image names and deprecated workflow references in the VaR tutorial.  It still relies on a custom worker image, although it uses the notebook itself as that image (to minimize potential mismatches).