### PR TITLE
remove minima dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,6 @@ ruby RUBY_VERSION
 #
 gem "jekyll", "3.5.1"
 
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima"
-
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    minima (1.2.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -52,7 +51,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 3.5.1)
   jekyll-asciidoc
-  minima
 
 RUBY VERSION
    ruby 2.4.1p111


### PR DESCRIPTION
The minima theme is not used by the project and is being removed to help
clean up the install process.