### PR TITLE
correct link to ophicleide setup list

### DIFF
--- a/_applications/ophicleide.adoc
+++ b/_applications/ophicleide.adoc
@@ -98,7 +98,7 @@ https://docs.openshift.org/latest/dev_guide/templates.html[OpenShift documentati
 
 Let's examine the template and explore the various objects that are created.
 
-file:/assets/ophicleide/ophicleide-setup-list.yaml[ophicleide-setup-list.yaml]
+link:/assets/ophicleide/ophicleide-setup-list.yaml[ophicleide-setup-list.yaml]
 
 This template encapsulates a `List` object which is used to bundle together
 the various components necessary for building and deploying Ophicleide. The


### PR DESCRIPTION
This fixes a bad markup tag in the asciidoc.