### PR TITLE
Add travis testing for resources.yaml changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,8 @@ before_install:
   fi
 
 install:
-  git clone https://github.com/radanalyticsio/oshinko-s2i
-  sudo chmod -R a+rwX $TEST_DIR/oshinko-s2i
+- git clone https://github.com/radanalyticsio/oshinko-s2i
+- sudo chmod -R a+rwX $TEST_DIR/oshinko-s2i
 
 before_script:
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
   # tests perform builds from the local source to do the tests
   include:
     - env: TO_TEST=pyspark-templates
-    - env: TEST_DIR2=`pwd`
   fast_finish: true
 
 before_install:
 ## add insecure-registry and restart docker
-- export TEST_DIR=`pwd` 
+- export TEST_DIR=`pwd`
+- export ORIGIN_DIR=$TEST_DIR/..
 - |
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
@@ -24,9 +24,7 @@ before_install:
           ## exit 0
       fi 
 
-      pwd
       echo $TEST_DIR
-      echo $TEST_DIR2
       bash --version
       sudo apt-get install --only-upgrade bash
       bash --version
@@ -37,27 +35,21 @@ before_install:
       sudo service docker start
       sudo service docker status
       ## chmod needs sudo, so all other commands are with sudo
-      sudo mkdir -p /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo chmod -R 766 /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo mkdir -p $ORIGIN_DIR
+      sudo chmod -R 766 $ORIGIN_DIR
       ## download oc 1.4.1 binary
-      sudo wget https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz -P ../origin/
-      sudo wget https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-server-v1.5.1-7b451fc-linux-64bit.tar.gz -P ../origin/
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo tar -C ../origin -xvzf /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz
-      sudo tar -C ../origin -xvzf /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server-v1.5.1-7b451fc-linux-64bit.tar.gz
-      sudo chmod -R 766 /home/travis/gopath/src/github.com/radanalyticsio/oshinko-s2i/
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server-v1.5.1-7b451fc-linux-64bit
-      sudo cp /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit/oc /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo cp /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server-v1.5.1-7b451fc-linux-64bit/* /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo chmod -R 766 /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo chmod -R +755 /home/travis/gopath/src/github.com/radanalyticsio/origin/*
-      sudo chmod -R a+rwX /home/travis/gopath/src/github.com/radanalyticsio/oshinko-s2i
-      sudo cp /home/travis/gopath/src/github.com/radanalyticsio/origin/* /bin
+      sudo wget https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz -P $ORIGIN_DIR
+      sudo wget https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-server-v1.5.1-7b451fc-linux-64bit.tar.gz -P $ORIGIN_DIR
+      sudo ls -l $ORIGIN_DIR
+      sudo tar -C $ORIGIN_DIR -xvzf $ORIGIN_DIR/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz
+      sudo tar -C $ORIGIN_DIR -xvzf $ORIGIN_DIR/openshift-origin-server-v1.5.1-7b451fc-linux-64bit.tar.gz
+      sudo cp $ORIGIN_DIR/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit/oc $ORIGIN_DIR
+      sudo cp $ORIGIN_DIR/openshift-origin-server-v1.5.1-7b451fc-linux-64bit/* $ORIGIN_DIR
+      sudo chmod -R +755 $ORIGIN_DIR/*
+      sudo cp $ORIGIN_DIR/origin/* /bin
       sudo ls -l /bin
       oc version
-      export PATH=$PATH:/home/travis/gopath/src/github.com/radanalyticsio/origin/
+      export PATH=$PATH:$ORIGIN_DIR
       echo $PATH
       # below cmd is important to get oc working in ubuntu
       sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v1.5.1 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
@@ -67,7 +59,7 @@ before_install:
       set +e
       built=false
       for tries in {1..3}; do
-          sudo oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+          sudo oc cluster up --host-config-dir=$ORIGIN_DIR
           if [ "$?" -eq 0 ]; then
               built=true
               break
@@ -81,7 +73,6 @@ before_install:
       fi
 
       sudo chmod -R a+rwX /home/travis/.kube
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
       # find IP:PORT of openshift
       IPSTR=`sudo oc status |grep server`
       echo $IPSTR
@@ -92,7 +83,9 @@ before_install:
   fi
 
 install:
-  git clone https://github.com/radanalyticsio/oshinko-s2i  
+  git clone https://github.com/radanalyticsio/oshinko-s2i
+  sudo chmod -R a+rwX $TEST_DIR/oshinko-s2i
+
 before_script:
 script:
 - echo $TEST_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ matrix:
   # no need to include the build target at present because the template
   # tests perform builds from the local source to do the tests
   include:
-    - env: TO_TEST=resources
+    - env: TO_TEST=pyspark-templates
   fast_finish: true
 
 before_install:
 ## add insecure-registry and restart docker
 - |
-  if [ "$TO_TEST" == "resources" ]; then
+  if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
       diff master_resources.yaml resources.yaml
       if [ "$?" -eq 0 ]; then
@@ -88,16 +88,10 @@ before_install:
   fi
 
 install:
+  git clone https://github.com/radanalyticsio/oshinko-s2i  
 before_script:
 script:
-- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.pyspark . ; fi
-- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.java . ; fi
-- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.scala . ; fi
-
-- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; make test-ephemeral ; fi
-- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; make test-pyspark-templates ; fi
-- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; make test-java-templates ; fi
-- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; make test-scala-templates ; fi
+- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-pyspark-templates ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,103 @@
+sudo: required
+dist: trusty
+language: go
+## home folder is /home/travis/gopath/src/github.com/radanalyticsio/oshinko-s2i
+services:
+- docker
+matrix:
+  # no need to include the build target at present because the template
+  # tests perform builds from the local source to do the tests
+  include:
+    - env: TO_TEST=resources
+  fast_finish: true
+
+before_install:
+## add insecure-registry and restart docker
+- |
+  if [ "$TO_TEST" == "resources" ]; then
+      wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
+      diff master_resources.yaml resources.yaml
+      if [ "$?" -eq 0 ]; then
+          exit 0
+      fi 
+
+      pwd
+      bash --version
+      sudo apt-get install --only-upgrade bash
+      bash --version
+      sudo cat /etc/default/docker
+      sudo service docker stop
+      sudo sed -i -e 's/sock/sock --insecure-registry 172.30.0.0\/16/' /etc/default/docker
+      sudo cat /etc/default/docker
+      sudo service docker start
+      sudo service docker status
+      ## chmod needs sudo, so all other commands are with sudo
+      sudo mkdir -p /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo chmod -R 766 /home/travis/gopath/src/github.com/radanalyticsio/origin
+      ## download oc 1.4.1 binary
+      sudo wget https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz -P ../origin/
+      sudo wget https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-server-v1.5.1-7b451fc-linux-64bit.tar.gz -P ../origin/
+      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo tar -C ../origin -xvzf /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz
+      sudo tar -C ../origin -xvzf /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server-v1.5.1-7b451fc-linux-64bit.tar.gz
+      sudo chmod -R 766 /home/travis/gopath/src/github.com/radanalyticsio/oshinko-s2i/
+      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit
+      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server-v1.5.1-7b451fc-linux-64bit
+      sudo cp /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit/oc /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo cp /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server-v1.5.1-7b451fc-linux-64bit/* /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo chmod -R 766 /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
+      sudo chmod -R +755 /home/travis/gopath/src/github.com/radanalyticsio/origin/*
+      sudo chmod -R a+rwX /home/travis/gopath/src/github.com/radanalyticsio/oshinko-s2i
+      sudo cp /home/travis/gopath/src/github.com/radanalyticsio/origin/* /bin
+      sudo ls -l /bin
+      oc version
+      export PATH=$PATH:/home/travis/gopath/src/github.com/radanalyticsio/origin/
+      echo $PATH
+      # below cmd is important to get oc working in ubuntu
+      sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v1.5.1 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
+
+      # Sometimes oc cluster up fails with a permission error and works when the test is relaunched.
+      # See if a retry within the same test works
+      set +e
+      built=false
+      for tries in {1..3}; do
+          sudo oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+          if [ "$?" -eq 0 ]; then
+              built=true
+              break
+          fi
+          echo "Retrying oc cluster up after failure"
+          sudo oc cluster down
+      done
+      set -e
+      if [ "$built" == false ]; then
+          exit 1
+      fi
+
+      sudo chmod -R a+rwX /home/travis/.kube
+      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
+      # find IP:PORT of openshift
+      IPSTR=`sudo oc status |grep server`
+      echo $IPSTR
+      IP=${IPSTR##*/}
+      echo ${IP}
+      IPSTR=`sudo oc login -u system:admin`
+      echo $IPSTR
+  fi
+
+install:
+before_script:
+script:
+- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.pyspark . ; fi
+- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.java . ; fi
+- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.scala . ; fi
+
+- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; make test-ephemeral ; fi
+- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; make test-pyspark-templates ; fi
+- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; make test-java-templates ; fi
+- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; make test-scala-templates ; fi
+notifications:
+ email:
+   on_success: never
+   on_failure: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
       diff master_resources.yaml resources.yaml
       if [ "$?" -eq 0 ]; then
+          echo "No change in resources.yaml, exiting ..."
           exit 0
       fi 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 
 before_install:
 ## add insecure-registry and restart docker
+  echo $TRAVIS_HOME
 - |
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,11 @@ before_install:
       sudo cp $ORIGIN_DIR/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit/oc $ORIGIN_DIR
       sudo cp $ORIGIN_DIR/openshift-origin-server-v1.5.1-7b451fc-linux-64bit/* $ORIGIN_DIR
       sudo chmod -R +755 $ORIGIN_DIR/*
-      sudo cp $ORIGIN_DIR/origin/* /bin
+      sudo cp $ORIGIN_DIR/* /bin
       sudo ls -l /bin
       oc version
-      export PATH=$PATH:$ORIGIN_DIR
-      echo $PATH
+      ## export PATH=$PATH:$ORIGIN_DIR
+      ## echo $PATH
       # below cmd is important to get oc working in ubuntu
       sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v1.5.1 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
       diff master_resources.yaml resources.yaml
       if [ "$?" -eq 0 ]; then
           echo "No change in resources.yaml, exiting ..."
-#          exit 0
+          ## exit 0
       fi 
 
       pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install:
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
       diff master_resources.yaml resources.yaml
-      if [ "$?" -eq 0 -a false ]; then
+      if [ "$?" -eq 0 ]; then
           echo "No change in resources.yaml, exiting ..."
-          exit 0
+#          exit 0
       fi 
 
       pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
       diff master_resources.yaml resources.yaml
-      if [ "$?" -eq 0 ]; then
+      if [ "$?" -eq 0 -a false ]; then
           echo "No change in resources.yaml, exiting ..."
           exit 0
       fi 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   # tests perform builds from the local source to do the tests
   include:
     - env: TO_TEST=pyspark-templates
+    - env: TEST_DIR2=`pwd`
   fast_finish: true
 
 before_install:
@@ -25,6 +26,7 @@ before_install:
 
       pwd
       echo $TEST_DIR
+      echo $TEST_DIR2
       bash --version
       sudo apt-get install --only-upgrade bash
       bash --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,9 +89,9 @@ install:
 
 before_script:
 script:
-- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-pyspark-templates ; fi
-- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-java-templates ; fi
-- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-scala-templates ; fi
+- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-pyspark-radio ; fi
+- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-java-radio ; fi
+- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-scala-radio ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 before_install:
 ## add insecure-registry and restart docker
-- echo $TRAVIS_HOME
+- export TEST_DIR=`pwd` 
 - |
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
@@ -24,6 +24,7 @@ before_install:
       fi 
 
       pwd
+      echo $TEST_DIR
       bash --version
       sudo apt-get install --only-upgrade bash
       bash --version
@@ -92,6 +93,7 @@ install:
   git clone https://github.com/radanalyticsio/oshinko-s2i  
 before_script:
 script:
+- echo $TEST_DIR
 - if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-pyspark-templates ; fi
 notifications:
  email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 before_install:
 ## add insecure-registry and restart docker
 - export TEST_DIR=`pwd`
-- export ORIGIN_DIR=$TEST_DIR/..
+- export ORIGIN_DIR=$TEST_DIR/../origin
 - |
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
   # tests perform builds from the local source to do the tests
   include:
     - env: TO_TEST=pyspark-templates
+    - env: TO_TEST=java-templates
+    - env: TO_TEST=scala-templates
   fast_finish: true
 
 before_install:
@@ -16,7 +18,6 @@ before_install:
 - export TEST_DIR=`pwd`
 - export ORIGIN_DIR=$TEST_DIR/../origin
 - |
-  if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
       diff master_resources.yaml resources.yaml
       if [ "$?" -eq 0 ]; then
@@ -80,16 +81,17 @@ before_install:
       echo ${IP}
       IPSTR=`sudo oc login -u system:admin`
       echo $IPSTR
-  fi
 
 install:
 - git clone https://github.com/radanalyticsio/oshinko-s2i
 - sudo chmod -R a+rwX $TEST_DIR/oshinko-s2i
+- cp resources.yaml $TEST_DIR/oshinko-s2i/test/e2e/resources
 
 before_script:
 script:
-- echo $TEST_DIR
 - if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-pyspark-templates ; fi
+- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-java-templates ; fi
+- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; cd oshinko-s2i; make test-scala-templates ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 before_install:
 ## add insecure-registry and restart docker
-  echo $TRAVIS_HOME
+- echo $TRAVIS_HOME
 - |
   if [ "$TO_TEST" == pyspark-templates ]; then
       wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml


### PR DESCRIPTION
This change adds travis testing for resources.yaml.  If resources.yaml is found to be different from the master branch, the oshinko-s2i template integration tests will be run for the templates defined by resources.yaml.