### PR TITLE
Remove default OSHINKO_CLUSTER_IMAGE setting in resources.yaml

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -647,8 +647,7 @@ items:
     parameters:
       - name: OSHINKO_CLUSTER_IMAGE
         description: Full name of the spark image to use when creating clusters
-        required: true
-        value: radanalyticsio/openshift-spark
+        required: false
       - name: OSHINKO_WEB_NAME
         description: Name of the oshinko web service
         value: "oshinko-web"


### PR DESCRIPTION
Recent changes in oshinko components move the default spark image
value into the various images/binaries so that known spark versions
can easily be associated with tagged images and release tarballs.
Accordingly, the webui template included in resources.yaml should
not set an explicit spark image override here.