### PR TITLE
update repo links for sparkpi-spring

### DIFF
--- a/_applications/spring_sparkpi.adoc
+++ b/_applications/spring_sparkpi.adoc
@@ -6,7 +6,7 @@
 :page-menu_template: menu_tutorial_application.html
 :page-menu_items: lightning
 :page-description: This source-to-image Java application combines the Apache Spark Pi estimation example with the popular Spring Boot framework. It provides an HTTP microservice which will calculate the value of Pi on demand.
-:page-project_links: ["https://github.com/radanalyticsio/spring-sparkpi"]
+:page-project_links: ["https://github.com/radanalyticsio/tutorial-sparkpi-java-spring"]
 
 [[introduction]]
 == Introduction
@@ -47,7 +47,7 @@ instructions:
 
    oc new-app --template oshinko-java-spark-build-dc \
        -p APPLICATION_NAME=spring-sparkpi \
-       -p GIT_URI=https://github.com/radanalyticsio/spring-sparkpi \
+       -p GIT_URI=https://github.com/radanalyticsio/tutorial-sparkpi-java-spring \
        -p APP_FILE=SparkPiBoot-0.0.1-SNAPSHOT.jar
 
 3. Expose an external route

--- a/assets/spring_sparkpi/lightning/index.html
+++ b/assets/spring_sparkpi/lightning/index.html
@@ -52,7 +52,7 @@
                   <pre class="fragment"><code data-trim class="bash">
 oc new-app --template oshinko-java-spark-build-dc \
     -p APPLICATION_NAME=spring-sparkpi \
-    -p GIT_URI=https://github.com/radanalyticsio/spring-sparkpi \
+    -p GIT_URI=https://github.com/radanalyticsio/tutorial-sparkpi-java-spring \
     -p APP_FILE=SparkPiBoot-0.0.1-SNAPSHOT.jar
                   </code></pre>
                   <pre class="fragment"><code data-trim class="bash">
@@ -72,7 +72,7 @@ Pi is rouuuughly 3.1335
 
                 <section>
                   <h2>Take it for a test drive</h2>
-                  <p>https://github.com/radanalyticsio/spring-sparkpi</p>
+                  <p>https://github.com/radanalyticsio/tutorial-sparkpi-java-spring</p>
                 </section>
                 <!-- Add more slides here as necessary, see the main reveal.js
                   docs for more information, https://github.com/hakimel/reveal.js


### PR DESCRIPTION
The code repository has been moved to tutorial-sparkpi-java-spring to
help align it with the other sparkpi applications. This is to accomodate
the upcoming "my first app" tutorial.