### PR TITLE
minor: Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository holds a [jekyll](https://jekyllrb.com) based site for the
 developer facing information about the radanalytics organization.
 
+For more details about contributing or running the site locally please
+consult [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Adding a sentence to `README.md` (that is displayed on github by default) about the `CONTRIBUTING.md`.

I missed the `CONTRIBUTING.md` file because there is a lot of other other files in the root directory. However, all the useful information is in this file, so I think it deserves the link from the `README.md`.