### PR TITLE
add app link to mnist tutorial

### DIFF
--- a/_applications/tensorflow_mnist.adoc
+++ b/_applications/tensorflow_mnist.adoc
@@ -5,7 +5,7 @@
 :page-layout: application
 :page-menu_template: menu_tutorial_application.html
 :page-description: This demo shows how to use source-to-image Tensorflow Serving build to deploy a tensorflow serving prediction endpoint on Openshift. The s2i build provides a GRPC microservice endpoint for web applications to send queries to be evaluated against the tensorflow model.
-:page-project_links: ["https://github.com/radanalyticsio/tensorflow-serving-s2i"]
+:page-project_links: ["https://github.com/sub-mod/mnist-app", "https://github.com/radanalyticsio/tensorflow-serving-s2i"]
 
 [[introduction]]
 == Introduction


### PR DESCRIPTION
This change adds a link to the app repository for the mnist tensorflow
tutorial.