### PR TITLE
Adding new liquid template for code snippets that can be copy&pasted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,3 +137,26 @@ in their headers. These variables are used in a similar manner as the Jekyll
 front matter variables. Although these attribute entries and front matter can
 co-exist within the current deployment framework, the preference should be to
 always use AsciiDoc attribute entries when possible.
+
+### A note on adding code block with a copy button
+
+If you want to add a code snippet that has the copy to clipboard button, you may
+want to use the liquid template called `copy_button.html`.
+
+To do that do following:
+* from AsciiDoc:
+  1. add `:page-liquid:` header
+  2.
+```bash
++++{% include copy_button.html lang='bash' text='
+<code goes here>
+'%}+++
+```
+* from Markdown:
+```bash
+{% include copy_button.html lang='bash' text='
+<code goes here>
+'%}
+```
+
+If argument `lang` is not specified, it defaults to 'bash' syntax.

--- a/_includes/copy_button.html
+++ b/_includes/copy_button.html
@@ -1,0 +1,6 @@
+<div class="language-{{ lang | default: 'bash'}} highlighter-rouge clipboard-pair" style="overflow-x: auto; display: flex;">
+  <pre style="flex:1; margin:0;padding:9px;" class="highlight">{{ include.text | default: 'no text' }}</pre>
+  <button class="copy-button" title="Click to copy me.">
+    <svg aria-hidden="true" class="octicon octicon-clippy" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg>
+  </button>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,5 +49,15 @@
     <!-- PatternFly -->
     <script src="/bower_components/patternfly/dist/js/patternfly.min.js"></script>
 
+    <!-- Clipboard -->
+    <script src="/bower_components/clipboard/dist/clipboard.min.js"></script>
+    <script type="text/javascript">
+      $(".clipboard-pair").each(function(index) {
+        $($(this).children()[0]).attr('id', 'clipboard-id-' + index);
+        $($(this).children()[1]).attr('data-clipboard-target', '#clipboard-id-' + index);
+      });
+      new Clipboard('.copy-button');
+    </script>
+
   </body>
 </html>

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
   "private": true,
   "ignore": [],
   "dependencies": {
-    "patternfly": "^3.24.0"
+    "patternfly": "^3.24.0",
+    "clipboard": "^1.7.1"
   }
 }

--- a/get-started.md
+++ b/get-started.md
@@ -60,17 +60,17 @@ may find this option easiest to start). Oshinko version 0.4.0 and newer require 
 
 First, install all the Oshinko resources into your project -
 
-```bash
+{% include copy_button.html lang='bash' text='
 oc create -f https://radanalytics.io/resources.yaml
-```
+'%}
 
 This creates the latest versions of the Oshinko S2I (source-to-image) templates and the Oshinko Web UI application, as well as a ServiceAccount and RoleBinding needed for creation and management of Apache Spark clusters. Look [here](https://github.com/radanalyticsio/radanalyticsio.github.io/tree/master/openshift) for instructions on how to use components from a specific Oshinko release.
 
 Second, start the Oshinko Web UI application -
 
-```bash
+{% include copy_button.html lang='bash' text='
 oc new-app oshinko-webui
-```
+'%}
 
 This creates the Oshinko Web UI, which can be used to manually create and manage Apache Spark clusters.
 


### PR DESCRIPTION
This is how it looks like on Chrome:

![peek 2017-11-09 16-15](https://user-images.githubusercontent.com/535866/32612803-779eeb86-c569-11e7-8b0b-ce2926d4610d.gif)

Usage:

* from adoc:
  1. add `:page-liquid:` header
  2. 
```bash
+++{% include copy_button.html lang='bash' text='
<code goes here>
'%}+++
```
* from markdown:
```bash
{% include copy_button.html lang='bash' text='
<code goes here>
'%}
```

If argument `lang` is not specified, it defaults to 'bash'.