### PR TITLE
fix links in my first app tutorials

### DIFF
--- a/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
@@ -665,6 +665,6 @@ Let's break this down a little. These first few lines are actually being generat
 
 The line beginning with `spark-submit` shows us the command which will run the application and the output afterwards is coming from Spring informing us that the application is starting.
 
-With your application now running on OpenShift please return to the link:/applications/my-first-radanalytics-app#user[My First RADanalytics Application page] to learn how to interact with this new microservice.
+With your application now running on OpenShift please return to the link:/my-first-radanalytics-app.html#user[My First RADanalytics Application page] to learn how to interact with this new microservice.
 
 You can find a reference implementation of this application in the RADanalytics GitHub organization at https://github.com/radanalyticsio/tutorial-sparkpi-java-spring

--- a/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
@@ -311,6 +311,6 @@ Let's break this down a little. These first few lines are actually being generat
 
 On the last two lines you see the `spark-submit` command which will run the application and the output from Flask informing us that it is listening on the host and port we specified.
 
-With your application now running on OpenShift please return to the link:/applications/my-first-radanalytics-app#user[My First RADanalytics Application page] to learn how to interact with this new microservice.
+With your application now running on OpenShift please return to the link:/my-first-radanalytics-app.html#user[My First RADanalytics Application page] to learn how to interact with this new microservice.
 
 You can find a reference implementation of this application in the RADanalytics GitHub organization at https://github.com/radanalyticsio/tutorial-sparkpi-python-flask


### PR DESCRIPTION
The return links at the bottom of the java and python tutorials were not
set properly. This change corrects the links and points them to the user
section of the my first app main tutorial page.