### PR TITLE
add bower folder to ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ _site
 .jekyll-metadata
 *.exe
 .idea
-
+bower_components


### PR DESCRIPTION
Just to ensure that we do not check in a directory full of bower
dependencies.