### PR TITLE
update resources.yaml file

### DIFF
--- a/_applications/grafzahl.adoc
+++ b/_applications/grafzahl.adoc
@@ -88,7 +88,7 @@ Forth, launch Graf Zahl himself, using the Oshinko pyspark S2I
 builder.
 
 ....
-oc new-app --template=oshinko-pyspark-build-dc \
+oc new-app --template=oshinko-python-build-dc \
            -p APPLICATION_NAME=grafzahl \
            -p GIT_URI=https://github.com/radanalyticsio/grafzahl \
            -p APP_ARGS=--servers=apache-kafka:9092 \

--- a/_applications/wine-map.adoc
+++ b/_applications/wine-map.adoc
@@ -79,7 +79,7 @@ The command below uses a special source-to-image builder to set up the pod envir
 The PostgreSQL driver and details are passed through as parameters and environment variables respectively.
 
 ....
-oc new-app --template=oshinko-pyspark-build-dc -p APPLICATION_NAME=winemap -p GIT_URI=https://github.com/radanalyticsio/winemap.git -p SPARK_OPTIONS='--packages org.postgresql:postgresql:42.1.4' -e SERVER=postgresql -e DBNAME=wineDb -e PASSWORD=password -e USER=username
+oc new-app --template=oshinko-python-build-dc -p APPLICATION_NAME=winemap -p GIT_URI=https://github.com/radanalyticsio/winemap.git -p SPARK_OPTIONS='--packages org.postgresql:postgresql:42.1.4' -e SERVER=postgresql -e DBNAME=wineDb -e PASSWORD=password -e USER=username
 ....
 
 You must then expose the application so that you can view the results,

--- a/_howdoi/how-to-connect-to-kafka.adoc
+++ b/_howdoi/how-to-connect-to-kafka.adoc
@@ -6,4 +6,4 @@ example, to start a new application with these options you could run the
 following:
 
 [source,bash]
-$ oc new-app --template=oshinko-pyspark-build-dc -p GIT_URI=[your source repo] -e SPARK_OPTIONS='--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0'
+$ oc new-app --template=oshinko-python-build-dc -p GIT_URI=[your source repo] -e SPARK_OPTIONS='--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0'

--- a/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
@@ -208,10 +208,10 @@ Make sure to note the location of your remote repository as you will need it in 
 
 == Build and run the application
 
-Now that all your files have been created, checked in and pushed to your online repository you are ready to command OpenShift to build and run your application. The following command will start the process, you can see that we are telling OpenShift to use the `oshinko-pyspark-build-dc` template for our application. This template contains the necessary components to invoke the Oshinko source-to-image builder. We also give our application a name and tell the builder where to find our source code. Issue the following command, making sure to enter your repository location for the `GIT_URI` parameter:
+Now that all your files have been created, checked in and pushed to your online repository you are ready to command OpenShift to build and run your application. The following command will start the process, you can see that we are telling OpenShift to use the `oshinko-python-build-dc` template for our application. This template contains the necessary components to invoke the Oshinko source-to-image builder. We also give our application a name and tell the builder where to find our source code. Issue the following command, making sure to enter your repository location for the `GIT_URI` parameter:
 
 ....
-oc new-app --template oshinko-pyspark-build-dc  \
+oc new-app --template oshinko-python-build-dc  \
     -p APPLICATION_NAME=sparkpi \
     -p GIT_URI=${YOUR_REPOSITORY_URI_HERE}
 ....
@@ -219,10 +219,10 @@ oc new-app --template oshinko-pyspark-build-dc  \
 Running this command should look something like this:
 
 ....
-$ oc new-app --template oshinko-pyspark-build-dc  \
+$ oc new-app --template oshinko-python-build-dc  \
 >     -p APPLICATION_NAME=sparkpi \
 >     -p GIT_URI=https://github.com/radanalyticsio/tutorial-sparkpi-python-flask.git
---> Deploying template "pi/oshinko-pyspark-build-dc" to project pi
+--> Deploying template "pi/oshinko-python-build-dc" to project pi
 
      PySpark
      ---------

--- a/resources.yaml
+++ b/resources.yaml
@@ -101,7 +101,7 @@ items:
               - name: OSHINKO_DEL_CLUSTER
                 value: ${OSHINKO_DEL_CLUSTER}
               - name: APP_EXIT
-                value: ${APP_EXIT}
+                value: "true"
               - name: OSHINKO_NAMED_CONFIG
                 value: ${OSHINKO_NAMED_CONFIG}
               - name: OSHINKO_SPARK_DRIVER_CONFIG
@@ -181,10 +181,6 @@ items:
       name: OSHINKO_DEL_CLUSTER
       required: true
       value: 'true'
-    - description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
-      name: APP_EXIT
-      required: true
-      value: 'false'
 
   - apiVersion: v1
     kind: Template
@@ -270,7 +266,7 @@ items:
               - name: OSHINKO_DEL_CLUSTER
                 value: ${OSHINKO_DEL_CLUSTER}
               - name: APP_EXIT
-                value: ${APP_EXIT}
+                value: "true"
               - name: OSHINKO_NAMED_CONFIG
                 value: ${OSHINKO_NAMED_CONFIG}
               - name: OSHINKO_SPARK_DRIVER_CONFIG
@@ -351,10 +347,6 @@ items:
       name: OSHINKO_DEL_CLUSTER
       required: true
       value: "true"
-    - description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
-      name: APP_EXIT
-      required: true
-      value: "false"
 
   - apiVersion: v1
     kind: Template
@@ -444,7 +436,7 @@ items:
               - name: OSHINKO_DEL_CLUSTER
                 value: ${OSHINKO_DEL_CLUSTER}
               - name: APP_EXIT
-                value: ${APP_EXIT}
+                value: "true"
               - name: OSHINKO_NAMED_CONFIG
                 value: ${OSHINKO_NAMED_CONFIG}
               - name: OSHINKO_SPARK_DRIVER_CONFIG
@@ -529,10 +521,6 @@ items:
       name: SBT_ARGS
     - description: Additional sbt arguments, useful for adding task arguments to sbt like `publish makePom`
       name: SBT_ARGS_APPEND
-    - description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
-      name: APP_EXIT
-      required: true
-      value: 'false'
 
   - apiVersion: v1
     kind: Template

--- a/resources.yaml
+++ b/resources.yaml
@@ -63,7 +63,7 @@ items:
             forcePull: true
             from:
               kind: DockerImage
-              name: radanalyticsio/radanalytics-pyspark
+              name: radanalyticsio/radanalytics-pyspark:stable
           type: Source
         triggers:
         - imageChange: {}
@@ -228,7 +228,7 @@ items:
             forcePull: true
             from:
               kind: DockerImage
-              name: radanalyticsio/radanalytics-java-spark
+              name: radanalyticsio/radanalytics-java-spark:stable
           type: Source
         triggers:
         - imageChange: {}
@@ -402,7 +402,7 @@ items:
             forcePull: true
             from:
               kind: DockerImage
-              name: radanalyticsio/radanalytics-scala-spark
+              name: radanalyticsio/radanalytics-scala-spark:stable
           type: Source
         triggers:
         - imageChange: {}

--- a/resources.yaml
+++ b/resources.yaml
@@ -24,364 +24,337 @@ items:
   - apiVersion: v1
     kind: Template
     labels:
-      application: oshinko-pyspark
-      createdBy: template-oshinko-pyspark-build-dc
+      application: oshinko-python-spark
+      createdBy: template-oshinko-python-spark-build-dc
     metadata:
       annotations:
-        openshift.io/display-name: PySpark
-        description: Create a buildconfig, imagestream and deploymentconfig using source-to-image and pyspark source hosted in git
-      name: oshinko-pyspark-build-dc
+        description: Create a buildconfig, imagestream and deploymentconfig using source-to-image and Python Spark source files hosted in git
+        openshift.io/display-name: Apache Spark Python
+      name: oshinko-python-build-dc
     objects:
-      - apiVersion: v1
-        kind: ImageStream
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          dockerImageRepository: ${APPLICATION_NAME}
-          tags:
-            - name: latest
-      - apiVersion: v1
-        kind: BuildConfig
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          output:
-            to:
+    - apiVersion: v1
+      kind: ImageStream
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        dockerImageRepository: ${APPLICATION_NAME}
+        tags:
+        - name: latest
+    - apiVersion: v1
+      kind: BuildConfig
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        output:
+          to:
+            kind: ImageStreamTag
+            name: ${APPLICATION_NAME}:latest
+        source:
+          contextDir: ${CONTEXT_DIR}
+          git:
+            ref: ${GIT_REF}
+            uri: ${GIT_URI}
+          type: Git
+        strategy:
+          sourceStrategy:
+            env:
+            - name: APP_FILE
+              value: ${APP_FILE}
+            forcePull: true
+            from:
+              kind: DockerImage
+              name: radanalyticsio/radanalytics-pyspark
+          type: Source
+        triggers:
+        - imageChange: {}
+          type: ImageChange
+        - type: ConfigChange
+        - github:
+            secret: ${APPLICATION_NAME}
+          type: GitHub
+        - generic:
+            secret: ${APPLICATION_NAME}
+          type: Generic
+    - apiVersion: v1
+      kind: DeploymentConfig
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        replicas: 1
+        selector:
+          deploymentconfig: ${APPLICATION_NAME}
+        strategy:
+          type: Rolling
+        template:
+          metadata:
+            labels:
+              deploymentconfig: ${APPLICATION_NAME}
+          spec:
+            containers:
+            - env:
+              - name: OSHINKO_CLUSTER_NAME
+                value: ${OSHINKO_CLUSTER_NAME}
+              - name: APP_ARGS
+                value: ${APP_ARGS}
+              - name: SPARK_OPTIONS
+                value: ${SPARK_OPTIONS}
+              - name: OSHINKO_DEL_CLUSTER
+                value: ${OSHINKO_DEL_CLUSTER}
+              - name: APP_EXIT
+                value: ${APP_EXIT}
+              - name: OSHINKO_NAMED_CONFIG
+                value: ${OSHINKO_NAMED_CONFIG}
+              - name: OSHINKO_SPARK_DRIVER_CONFIG
+                value: ${OSHINKO_SPARK_DRIVER_CONFIG}
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              image: ${APPLICATION_NAME}
+              imagePullPolicy: IfNotPresent
+              name: ${APPLICATION_NAME}
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              volumeMounts:
+              - mountPath: /etc/podinfo
+                name: podinfo
+                readOnly: false
+            dnsPolicy: ClusterFirst
+            restartPolicy: Always
+            serviceAccount: oshinko
+            volumes:
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    fieldPath: metadata.labels
+                  path: labels
+              name: podinfo
+        triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${APPLICATION_NAME}
+            from:
               kind: ImageStreamTag
               name: ${APPLICATION_NAME}:latest
-          source:
-            git:
-              ref: ${GIT_REF}
-              uri: ${GIT_URI}
-            type: Git
-          strategy:
-            sourceStrategy:
-              type: Source
-              env:
-                - name: APP_FILE
-                  value: ${APP_FILE}
-              forcePull: true
-              from:
-                kind: DockerImage
-                name: radanalyticsio/radanalytics-pyspark:stable
-          triggers:
-            - type: ConfigChange
-            - type: ImageChange
-              imageChange: {}
-            - type: GitHub
-              github:
-                secret: ${APPLICATION_NAME}
-            - type: Generic
-              generic:
-                secret: ${APPLICATION_NAME}
-      - apiVersion: v1
-        kind: DeploymentConfig
-        metadata:
-          labels:
-            app: ${APPLICATION_NAME}
-          name: ${APPLICATION_NAME}
-        spec:
-          replicas: 1
-          selector:
-            deploymentconfig: ${APPLICATION_NAME}
-          strategy:
-            type: Rolling
-          template:
-            metadata:
-              labels:
-                deploymentconfig: ${APPLICATION_NAME}
-                app: ${APPLICATION_NAME}
-            spec:
-              containers:
-                - name: ${APPLICATION_NAME}
-                  image: ${APPLICATION_NAME}
-                  imagePullPolicy: Always
-                  resources: {}
-                  terminationMessagePath: /dev/termination-log
-                  env:
-                    - name: OSHINKO_CLUSTER_NAME
-                      value: ${OSHINKO_CLUSTER_NAME}
-                    - name: APP_ARGS
-                      value: ${APP_ARGS}
-                    - name: SPARK_OPTIONS
-                      value: ${SPARK_OPTIONS}
-                    - name: OSHINKO_DEL_CLUSTER
-                      value: ${OSHINKO_DEL_CLUSTER}
-                    - name: APP_EXIT
-                      value: "true"
-                    - name: OSHINKO_NAMED_CONFIG
-                      value: ${OSHINKO_NAMED_CONFIG}
-                    - name: OSHINKO_SPARK_DRIVER_CONFIG
-                      value: ${OSHINKO_SPARK_DRIVER_CONFIG}
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                  volumeMounts:
-                  - mountPath: /etc/podinfo
-                    name: podinfo
-                    readOnly: false
-              dnsPolicy: ClusterFirst
-              restartPolicy: Always
-              serviceAccount: oshinko
-              volumes:
-              - downwardAPI:
-                  items:
-                  - fieldRef:
-                      fieldPath: metadata.labels
-                    path: labels
-                name: podinfo
-          triggers:
-            - type: ConfigChange
-            - type: ImageChange
-              imageChangeParams:
-                automatic: true
-                containerNames:
-                  - ${APPLICATION_NAME}
-                from:
-                  kind: ImageStreamTag
-                  name: ${APPLICATION_NAME}:latest
-      - apiVersion: v1
-        kind: Service
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          ports:
-            - name: 8080-tcp
-              port: 8080
-              protocol: TCP
-              targetPort: 8080
-          selector:
-            deploymentconfig: ${APPLICATION_NAME}
+          type: ImageChange
+        - type: ConfigChange
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+        selector:
+          deploymentConfig: ${APPLICATION_NAME}
     parameters:
-      - name: APPLICATION_NAME
-        displayName: Application Name
-        description: The name to use for the BuildConfig, ImageStream and DeploymentConfig components
-        from: pyspark-[a-z0-9]{4}
-        generate: expression
-      - name: GIT_URI
-        displayName: Git Repository URL
-        description: The URL of the repository with your application source code
-        required: true
-      - name: APP_ARGS
-        displayName: Application Arguments
-        description: Command line arguments to pass to the application
-      - name: SPARK_OPTIONS
-        displayName: spark-submit Options
-        description: List of additional options to pass to spark-submit (for exmaple --conf property=value or --package ...). --master and --class are set by the launcher and should not be set here.
-      - name: GIT_REF
-        displayName: Git Reference
-        description: Optional branch, tag or commit
-      - name: OSHINKO_CLUSTER_NAME
-        description: The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.
-      - name: OSHINKO_NAMED_CONFIG
-        description: The name of a stored cluster configuration to use if a cluster is created, default is 'default'.
-      - name: OSHINKO_SPARK_DRIVER_CONFIG
-        description: The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.
-      - name: OSHINKO_DEL_CLUSTER
-        description: If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'
-        value: "true"
-        required: true
-      - name: APP_FILE
-        description: The name of the main py file to run. If this is not specified and there is a single py file at top level of the git respository, that file will be chosen.
+    - description: 'The name to use for the buildconfig, imagestream and deployment components'
+      from: 'python-spark-[a-z0-9]{4}'
+      generate: expression
+      name: APPLICATION_NAME
+      required: true
+    - description: The URL of the repository with your application source code
+      displayName: Git Repository URL
+      name: GIT_URI
+    - description: Optional branch, tag or commit
+      displayName: Git Reference
+      name: GIT_REF
+    - description: Git sub-directory path
+      name: CONTEXT_DIR
+    - description: The name of the main py file to run. If this is not specified and there is a single py file at top level of the git respository, that file will be chosen.
+      name: APP_FILE
+    - description: Command line arguments to pass to the Spark application
+      name: APP_ARGS
+    - description: List of additional Spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here
+      name: SPARK_OPTIONS
+    - description: The name of the Spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.
+      name: OSHINKO_CLUSTER_NAME
+    - description: The name of a stored cluster configuration to use if a cluster is created, default is 'default'.
+      name: OSHINKO_NAMED_CONFIG
+    - description: The name of a configmap to use for the Spark configuration of the driver. If this configmap is empty the default Spark configuration will be used.
+      name: OSHINKO_SPARK_DRIVER_CONFIG
+    - description: If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'
+      name: OSHINKO_DEL_CLUSTER
+      required: true
+      value: 'true'
+    - description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
+      name: APP_EXIT
+      required: true
+      value: 'false'
 
   - apiVersion: v1
     kind: Template
     labels:
       application: oshinko-java-spark
-      createdBy: template-oshinko-java-build-dc
+      createdBy: template-oshinko-java-spark-build-dc
     metadata:
       annotations:
-        openshift.io/display-name: JavaSpark
-        description: Create a buildconfig, imagestream and deploymentconfig using source-to-image and java spark source hosted in git
+        description: Create a buildconfig, imagestream and deploymentconfig using source-to-image and Java Spark source files hosted in git'
+        openshift.io/display-name: Apache Spark Java
       name: oshinko-java-spark-build-dc
     objects:
-      - apiVersion: v1
-        kind: ImageStream
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          dockerImageRepository: ${APPLICATION_NAME}
-          tags:
-            - name: latest
-      - apiVersion: v1
-        kind: BuildConfig
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          output:
-            to:
+    - apiVersion: v1
+      kind: ImageStream
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        dockerImageRepository: ${APPLICATION_NAME}
+        tags:
+        - name: latest
+    - apiVersion: v1
+      kind: BuildConfig
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        output:
+          to:
+            kind: ImageStreamTag
+            name: ${APPLICATION_NAME}:latest
+        source:
+          contextDir: ${CONTEXT_DIR}
+          git:
+            ref: ${GIT_REF}
+            uri: ${GIT_URI}
+          type: Git
+        strategy:
+          sourceStrategy:
+            env:
+            - name: APP_FILE
+              value: ${APP_FILE}
+            forcePull: true
+            from:
+              kind: DockerImage
+              name: radanalyticsio/radanalytics-java-spark
+          type: Source
+        triggers:
+        - imageChange: {}
+          type: ImageChange
+        - type: ConfigChange
+        - github:
+            secret: ${APPLICATION_NAME}
+          type: GitHub
+        - generic:
+            secret: ${APPLICATION_NAME}
+          type: Generic
+    - apiVersion: v1
+      kind: DeploymentConfig
+      metadata:
+        labels:
+          deploymentConfig: ${APPLICATION_NAME}
+        name: ${APPLICATION_NAME}
+      spec:
+        replicas: 1
+        selector:
+          deploymentConfig: ${APPLICATION_NAME}
+        strategy:
+          type: Rolling
+        template:
+          metadata:
+            labels:
+              deploymentConfig: ${APPLICATION_NAME}
+          spec:
+            containers:
+            - env:
+              - name: OSHINKO_CLUSTER_NAME
+                value: ${OSHINKO_CLUSTER_NAME}
+              - name: APP_ARGS
+                value: ${APP_ARGS}
+              - name: SPARK_OPTIONS
+                value: ${SPARK_OPTIONS}
+              - name: APP_MAIN_CLASS
+                value: ${APP_MAIN_CLASS}
+              - name: OSHINKO_DEL_CLUSTER
+                value: ${OSHINKO_DEL_CLUSTER}
+              - name: APP_EXIT
+                value: ${APP_EXIT}
+              - name: OSHINKO_NAMED_CONFIG
+                value: ${OSHINKO_NAMED_CONFIG}
+              - name: OSHINKO_SPARK_DRIVER_CONFIG
+                value: ${OSHINKO_SPARK_DRIVER_CONFIG}
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              image: ${APPLICATION_NAME}
+              imagePullPolicy: IfNotPresent
+              name: ${APPLICATION_NAME}
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              volumeMounts:
+              - mountPath: /etc/podinfo
+                name: podinfo
+                readOnly: false
+            dnsPolicy: ClusterFirst
+            restartPolicy: Always
+            serviceAccount: oshinko
+            volumes:
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    fieldPath: metadata.labels
+                  path: labels
+              name: podinfo
+        triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${APPLICATION_NAME}
+            from:
               kind: ImageStreamTag
               name: ${APPLICATION_NAME}:latest
-          source:
-            git:
-              ref: ${GIT_REF}
-              uri: ${GIT_URI}
-            type: Git
-          strategy:
-            sourceStrategy:
-              type: Source
-              env:
-                - name: APP_FILE
-                  value: ${APP_FILE}
-              forcePull: true
-              from:
-                kind: DockerImage
-                name: radanalyticsio/radanalytics-java-spark:stable
-          triggers:
-            - type: ConfigChange
-            - type: ImageChange
-              imageChange: {}
-            - type: GitHub
-              github:
-                secret: ${APPLICATION_NAME}
-            - type: Generic
-              generic:
-                secret: ${APPLICATION_NAME}
-      - apiVersion: v1
-        kind: DeploymentConfig
-        metadata:
-          labels:
-            app: ${APPLICATION_NAME}
-          name: ${APPLICATION_NAME}
-        spec:
-          replicas: 1
+          type: ImageChange
+        - type: ConfigChange
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
           selector:
-            deploymentconfig: ${APPLICATION_NAME}
-          strategy:
-            type: Rolling
-          template:
-            metadata:
-              labels:
-                deploymentconfig: ${APPLICATION_NAME}
-                app: ${APPLICATION_NAME}
-            spec:
-              containers:
-                - name: ${APPLICATION_NAME}
-                  image: ${APPLICATION_NAME}
-                  imagePullPolicy: Always
-                  resources: {}
-                  terminationMessagePath: /dev/termination-log
-                  env:
-                    - name: OSHINKO_CLUSTER_NAME
-                      value: ${OSHINKO_CLUSTER_NAME}
-                    - name: APP_ARGS
-                      value: ${APP_ARGS}
-                    - name: SPARK_OPTIONS
-                      value: ${SPARK_OPTIONS}
-                    - name: APP_MAIN_CLASS
-                      value: ${APP_MAIN_CLASS}
-                    - name: OSHINKO_DEL_CLUSTER
-                      value: ${OSHINKO_DEL_CLUSTER}
-                    - name: APP_EXIT
-                      value: "true"
-                    - name: OSHINKO_NAMED_CONFIG
-                      value: ${OSHINKO_NAMED_CONFIG}
-                    - name: OSHINKO_SPARK_DRIVER_CONFIG
-                      value: ${OSHINKO_SPARK_DRIVER_CONFIG}
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                  volumeMounts:
-                  - mountPath: /etc/podinfo
-                    name: podinfo
-                    readOnly: false
-              dnsPolicy: ClusterFirst
-              restartPolicy: Always
-              serviceAccount: oshinko
-              volumes:
-              - downwardAPI:
-                  items:
-                  - fieldRef:
-                      fieldPath: metadata.labels
-                    path: labels
-                name: podinfo
-          triggers:
-            - type: ConfigChange
-            - type: ImageChange
-              imageChangeParams:
-                automatic: true
-                containerNames:
-                  - ${APPLICATION_NAME}
-                from:
-                  kind: ImageStreamTag
-                  name: ${APPLICATION_NAME}:latest
-      - apiVersion: v1
-        kind: Service
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          ports:
-            - name: 8080-tcp
-              port: 8080
-              protocol: TCP
-              targetPort: 8080
-          selector:
-            deploymentconfig: ${APPLICATION_NAME}
+          deploymentConfig: ${APPLICATION_NAME}
     parameters:
-      - name: APPLICATION_NAME
-        displayName: Application Name
-        description: |-
-          The name to use for the BuildConfig, ImageStream and
-          DeploymentConfig components
-        from: java-[a-z0-9]{4}
-        generate: expression
-      - name: GIT_URI
-        displayName: Git Repository URL
-        description: |-
-          The URL of the repository with your application source code
-        required: true
-      - name: APP_MAIN_CLASS
-        description: Application main class for jar-based applications
-      - name: APP_ARGS
-        displayName: Application Arguments
-        description: Command line arguments to pass to the application
-      - name: SPARK_OPTIONS
-        displayName: spark-submit Options
-        description: |-
-          List of additional options to pass to spark-submit (for exmaple
-          --conf property=value or --package ...). --master and --class are
-          set by the launcher and should not be set here.
-      - name: GIT_REF
-        displayName: Git Reference
-        description: Optional branch, tag or commit
-      - name: OSHINKO_CLUSTER_NAME
-        description: |-
-          The name of the spark cluster to run against. The cluster will be
-          created if it does not exist, and a random cluster name will be
-          chosen if this value is left blank.
-      - name: OSHINKO_NAMED_CONFIG
-        description: |-
-          The name of a stored cluster configuration to use if a cluster is
-          created, default is 'default'.
-      - name: OSHINKO_SPARK_DRIVER_CONFIG
-        description: |-
-          The name of a configmap to use for the spark configuration of the
-          driver. If this configmap is empty the default spark configuration
-          will be used.
-      - name: OSHINKO_DEL_CLUSTER
-        description: |-
-          If a cluster is created on-demand, delete the cluster when the
-          application finishes if this option is set to 'true'
-        value: "true"
-        required: true
-      - name: APP_FILE
-        description: |-
-          The name of the main JAR file. If this is not specified and there is
-          a single JAR produced by the build, that JAR will be chosen.
+    - description: 'The name to use for the buildconfig, imagestream and deployment objects'
+      from: 'java-spark-[a-z0-9]{4}'
+      generate: expression
+      name: APPLICATION_NAME
+      required: true
+    - description: Git source URI for application
+      name: GIT_URI
+    - description: Git branch/tag reference
+      name: GIT_REF
+      value: master
+    - description: Git sub-directory path
+      name: CONTEXT_DIR
+    - description: The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.
+      name: APP_FILE
+    - description: Command line arguments to pass to the Spark application
+      name: APP_ARGS
+    - description: Application main class for jar-based applications
+      name: APP_MAIN_CLASS
+    - description: List of additional Spark options to pass to spark-submit (for example --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here
+      name: SPARK_OPTIONS
+    - description: The name of the Spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.
+      name: OSHINKO_CLUSTER_NAME
+    - description: The name of a stored cluster configuration to use if a cluster is created, default is 'default'.
+      name: OSHINKO_NAMED_CONFIG
+    - description: The name of a configmap to use for the Spark configuration of the driver. If this configmap is empty the default Spark configuration will be used.
+      name: OSHINKO_SPARK_DRIVER_CONFIG
+    - description: If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'
+      name: OSHINKO_DEL_CLUSTER
+      required: true
+      value: "true"
+    - description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
+      name: APP_EXIT
+      required: true
+      value: "false"
 
   - apiVersion: v1
     kind: Template
@@ -390,184 +363,177 @@ items:
       createdBy: template-oshinko-scala-spark-build-dc
     metadata:
       annotations:
-        description: Create a buildconfig, imagestream and deploymentconfig using source-to-image and Scala Spark source hosted in git
+        description: Create a buildconfig, imagestream and deploymentconfig using source-to-image and Scala Spark source files hosted in git
+        openshift.io/display-name: Apache Spark Scala
       name: oshinko-scala-spark-build-dc
     objects:
-      - apiVersion: v1
-        kind: ImageStream
-        metadata:
-          name: ${APPLICATION_NAME}
-        spec:
-          dockerImageRepository: ${APPLICATION_NAME}
-          tags:
-            - name: latest
-      - apiVersion: v1
-        kind: BuildConfig
-        metadata:
-          name: ${APPLICATION_NAME}
-        spec:
-          output:
-            to:
+    - apiVersion: v1
+      kind: ImageStream
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        dockerImageRepository: ${APPLICATION_NAME}
+        tags:
+        - name: latest
+    - apiVersion: v1
+      kind: BuildConfig
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        output:
+          to:
+            kind: ImageStreamTag
+            name: ${APPLICATION_NAME}:latest
+        source:
+          contextDir: ${CONTEXT_DIR}
+          git:
+            ref: ${GIT_REF}
+            uri: ${GIT_URI}
+          type: Git
+        strategy:
+          sourceStrategy:
+            env:
+            - name: APP_FILE
+              value: ${APP_FILE}
+            - name: SBT_ARGS
+              value: ${SBT_ARGS}
+            - name: SBT_ARGS_APPEND
+              value: ${SBT_ARGS_APPEND}
+            forcePull: true
+            from:
+              kind: DockerImage
+              name: radanalyticsio/radanalytics-scala-spark
+          type: Source
+        triggers:
+        - imageChange: {}
+          type: ImageChange
+        - type: ConfigChange
+        - github:
+            secret: ${APPLICATION_NAME}
+          type: GitHub
+        - generic:
+            secret: ${APPLICATION_NAME}
+          type: Generic
+    - apiVersion: v1
+      kind: DeploymentConfig
+      metadata:
+        labels:
+          deploymentConfig: ${APPLICATION_NAME}
+        name: ${APPLICATION_NAME}
+      spec:
+        replicas: 1
+        selector:
+          deploymentConfig: ${APPLICATION_NAME}
+        strategy:
+          type: Rolling
+        template:
+          metadata:
+            labels:
+              deploymentConfig: ${APPLICATION_NAME}
+          spec:
+            containers:
+            - env:
+              - name: OSHINKO_CLUSTER_NAME
+                value: ${OSHINKO_CLUSTER_NAME}
+              - name: APP_ARGS
+                value: ${APP_ARGS}
+              - name: SPARK_OPTIONS
+                value: ${SPARK_OPTIONS}
+              - name: APP_MAIN_CLASS
+                value: ${APP_MAIN_CLASS}
+              - name: OSHINKO_DEL_CLUSTER
+                value: ${OSHINKO_DEL_CLUSTER}
+              - name: APP_EXIT
+                value: ${APP_EXIT}
+              - name: OSHINKO_NAMED_CONFIG
+                value: ${OSHINKO_NAMED_CONFIG}
+              - name: OSHINKO_SPARK_DRIVER_CONFIG
+                value: ${OSHINKO_SPARK_DRIVER_CONFIG}
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              image: ${APPLICATION_NAME}
+              imagePullPolicy: IfNotPresent
+              name: ${APPLICATION_NAME}
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              volumeMounts:
+              - mountPath: /etc/podinfo
+                name: podinfo
+                readOnly: false
+            dnsPolicy: ClusterFirst
+            restartPolicy: Always
+            serviceAccount: oshinko
+            volumes:
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    fieldPath: metadata.labels
+                  path: labels
+              name: podinfo
+        triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${APPLICATION_NAME}
+            from:
               kind: ImageStreamTag
               name: ${APPLICATION_NAME}:latest
-          source:
-            git:
-              ref: ${GIT_REF}
-              uri: ${GIT_URI}
-            type: Git
-          strategy:
-            sourceStrategy:
-              type: Source
-              env:
-                - name: APP_FILE
-                  value: ${APP_FILE}
-              forcePull: true
-              from:
-                kind: DockerImage
-                name: radanalyticsio/radanalytics-scala-spark:stable
-          triggers:
-            - type: ConfigChange
-            - type: ImageChange
-              imageChange: {}
-            - type: GitHub
-              github:
-                secret: ${APPLICATION_NAME}
-            - type: Generic
-              generic:
-                secret: ${APPLICATION_NAME}
-      - apiVersion: v1
-        kind: DeploymentConfig
-        metadata:
-          labels:
-            deploymentConfig: ${APPLICATION_NAME}
-          name: ${APPLICATION_NAME}
-        spec:
-          replicas: 1
-          selector:
-            deploymentConfig: ${APPLICATION_NAME}
-          strategy:
-            type: Rolling
-          template:
-            metadata:
-              labels:
-                deploymentConfig: ${APPLICATION_NAME}
-            spec:
-              containers:
-                - name: ${APPLICATION_NAME}
-                  image: ${APPLICATION_NAME}
-                  imagePullPolicy: Always
-                  resources: {}
-                  terminationMessagePath: /dev/termination-log
-                  env:
-                    - name: OSHINKO_CLUSTER_NAME
-                      value: ${OSHINKO_CLUSTER_NAME}
-                    - name: APP_ARGS
-                      value: ${APP_ARGS}
-                    - name: SPARK_OPTIONS
-                      value: ${SPARK_OPTIONS}
-                    - name: APP_MAIN_CLASS
-                      value: ${APP_MAIN_CLASS}
-                    - name: OSHINKO_DEL_CLUSTER
-                      value: ${OSHINKO_DEL_CLUSTER}
-                    - name: APP_EXIT
-                      value: "true"
-                    - name: OSHINKO_NAMED_CONFIG
-                      value: ${OSHINKO_NAMED_CONFIG}
-                    - name: OSHINKO_SPARK_DRIVER_CONFIG
-                      value: ${OSHINKO_SPARK_DRIVER_CONFIG}
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                  volumeMounts:
-                    - mountPath: /etc/podinfo
-                      name: podinfo
-                      readOnly: false
-              dnsPolicy: ClusterFirst
-              restartPolicy: Always
-              serviceAccount: oshinko
-              volumes:
-                - downwardAPI:
-                    items:
-                      - fieldRef:
-                          fieldPath: metadata.labels
-                        path: labels
-                  name: podinfo
-          triggers:
-            - type: ConfigChange
-            - type: ImageChange
-              imageChangeParams:
-                automatic: true
-                containerNames:
-                  - ${APPLICATION_NAME}
-                from:
-                  kind: ImageStreamTag
-                  name: ${APPLICATION_NAME}:latest
-      - apiVersion: v1
-        kind: Service
-        metadata:
-          name: ${APPLICATION_NAME}
-          labels:
-            app: ${APPLICATION_NAME}
-        spec:
-          ports:
-            - name: 8080-tcp
-              port: 8080
-              protocol: TCP
-              targetPort: 8080
-          selector:
-            deploymentconfig: ${APPLICATION_NAME}
+          type: ImageChange
+        - type: ConfigChange
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: ${APPLICATION_NAME}
+      spec:
+        ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+        selector:
+          deploymentConfig: ${APPLICATION_NAME}
     parameters:
-      - name: APPLICATION_NAME
-        displayName: Application Name
-        description: |-
-          The name to use for the BuildConfig, ImageStream and
-          DeploymentConfig components
-        from: scala-[a-z0-9]{4}
-        generate: expression
-      - name: GIT_URI
-        displayName: Git Repository URL
-        description: |-
-          The URL of the repository with your application source code
-        required: true
-      - name: APP_MAIN_CLASS
-        description: Application main class for jar-based applications
-      - name: APP_ARGS
-        displayName: Application Arguments
-        description: Command line arguments to pass to the application
-      - name: SPARK_OPTIONS
-        displayName: spark-submit Options
-        description: |-
-          List of additional options to pass to spark-submit (for exmaple
-          --conf property=value or --package ...). --master and --class are
-          set by the launcher and should not be set here.
-      - name: GIT_REF
-        displayName: Git Reference
-        description: Optional branch, tag or commit
-      - name: OSHINKO_CLUSTER_NAME
-        description: |-
-          The name of the spark cluster to run against. The cluster will be
-          created if it does not exist, and a random cluster name will be
-          chosen if this value is left blank.
-      - name: OSHINKO_NAMED_CONFIG
-        description: |-
-          The name of a stored cluster configuration to use if a cluster is
-          created, default is 'default'.
-      - name: OSHINKO_SPARK_DRIVER_CONFIG
-        description: |-
-          The name of a configmap to use for the spark configuration of the
-          driver. If this configmap is empty the default spark configuration
-          will be used.
-      - name: OSHINKO_DEL_CLUSTER
-        description: |-
-          If a cluster is created on-demand, delete the cluster when the
-          application finishes if this option is set to 'true'
-        value: "true"
-        required: true
-      - name: APP_FILE
-        description: |-
-          The name of the main JAR file. If this is not specified and there is
-          a single JAR produced by the build, that JAR will be chosen.
+    - description: The name to use for the buildconfig, imagestream and deployment objects
+      from: 'scala-spark-[a-z0-9]{4}'
+      generate: expression
+      name: APPLICATION_NAME
+      required: true
+    - description: Git source URI for application
+      name: GIT_URI
+    - description: Git branch/tag reference
+      name: GIT_REF
+      value: master
+    - description: Git sub-directory path
+      name: CONTEXT_DIR
+    - description: The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.
+      name: APP_FILE
+    - description: Command line arguments to pass to the spark application
+      name: APP_ARGS
+    - description: Application main class for jar-based applications
+      name: APP_MAIN_CLASS
+    - description: List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here
+      name: SPARK_OPTIONS
+    - description: The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.
+      name: OSHINKO_CLUSTER_NAME
+    - description: The name of a stored cluster configuration to use if a cluster is created, default is 'default'.
+      name: OSHINKO_NAMED_CONFIG
+    - description: The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.
+      name: OSHINKO_SPARK_DRIVER_CONFIG
+    - description: If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'
+      name: OSHINKO_DEL_CLUSTER
+      required: true
+      value: 'true'
+    - description: Arguments to use when calling sbt, replacing the default `package`
+      name: SBT_ARGS
+    - description: Additional sbt arguments, useful for adding task arguments to sbt like `publish makePom`
+      name: SBT_ARGS_APPEND
+    - description: Setting this value to 'false' prevents the application from being re-deployed if/when it completes
+      name: APP_EXIT
+      required: true
+      value: 'false'
+
   - apiVersion: v1
     kind: Template
     template: oshinko-webui-secure


### PR DESCRIPTION
This change brings parity to the build-dc templates that exist within
the resources.yaml manifest. It also updates individual tutorials and
documentation that referred to the older `oshinko-pyspark-build-dc`
templates.