### PR TITLE
fix selector for java service

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -332,7 +332,7 @@ items:
           port: 8080
           protocol: TCP
           targetPort: 8080
-          selector:
+        selector:
           deploymentConfig: ${APPLICATION_NAME}
     parameters:
     - description: 'The name to use for the buildconfig, imagestream and deployment objects'


### PR DESCRIPTION
the service object in the java s2i template was not properly configured,
there was an indent error in the yaml that went unnoticed.