### PR TITLE
Changed `chmod` argument order for macOS compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ this methodology run the following:
 
 ```
 $ cd radanalytics.github.io
-$ chmod go+rX -R .
+$ chmod -R go+rX .
 $ docker build -t radanalytics.io .
 $ docker run --rm -it -p 4000:4000 radanalytics.io
 ```


### PR DESCRIPTION
Since in Linux, `chmod` can take both `[arg] mode file` and `mode [arg] file` but macOS' `chmod` only accepts `[arg] mode file`, the instructions on `CONTRIBUTING.md` were changed to work in both OSes.