### PR TITLE
add note about version info to kafka how do i

### DIFF
--- a/_howdoi/how-to-connect-to-kafka.adoc
+++ b/_howdoi/how-to-connect-to-kafka.adoc
@@ -7,3 +7,6 @@ following:
 
 [source,bash]
 $ oc new-app --template=oshinko-python-spark-build-dc -p GIT_URI=[your source repo] -e SPARK_OPTIONS='--packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.1.0'
+
+*Note* In this example the Apache Spark version is `2.1.0`, you will need to
+change this version information to match the version of Spark you are using.


### PR DESCRIPTION
The version in the example is `2.1.0`, this change adds a warning note
to the user about the need to change this value when using different
Spark versions.