### PR TITLE
Update Streaming ALS presentation links

### DIFF
--- a/_presentations/building_streaming_recommendation_engines_on_spark.adoc
+++ b/_presentations/building_streaming_recommendation_engines_on_spark.adoc
@@ -1,8 +1,8 @@
 = Building Streaming Recommendation Engines on Spark
 :page-presentor: Rui Vieira
 :page-date: 2018-01-27
-:page-media-url: https://www.youtube.com/watch?v=oUv9MhVaMA8
-:page-slides-url: https://github.com/ruivieira/presentations/blob/master/building_streaming_recommendation_engines_on_spark.pdf
+:page-media-url: https://youtu.be/-bR3d5h9SWc
+:page-slides-url: https://github.com/ruivieira/presentations/blob/master/streaming-als/2018-06-11-berlin-buzzwords-streaming-als.pdf
 
 Collaborative filtering is a well known method to implement recommendation engines. Although modern techniques, such as Alternating Least Squares (ALS), allow us to perform rating predictions with large amounts of observations, typically ALS is implemented as a distributed batch algorithm where retraining must be performed with the entirety of the data. However, when dealing with large amounts of data as a stream, batch retraining might be problematic.
 


### PR DESCRIPTION
Links to pointing to the latest version of this presentation (Berlin Buzzwords 2018)