### PR TITLE
fix link in sparkpi tutorials

### DIFF
--- a/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
@@ -8,7 +8,7 @@
 
 These instructions will help you to create a SparkPi microservice using the https://www.oracle.com/java[Java language] and the https://spring.io/[Spring framework].
 
-You should already have the necessary prerequisites installed and configured, but if not please review the link:/applications/my-first-radanalytics-app[instructions].
+You should already have the necessary prerequisites installed and configured, but if not please review the link:/my-first-radanalytics-app.html[instructions].
 
 == Create the application source files
 

--- a/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
@@ -8,7 +8,7 @@
 
 These instructions will help you to create a SparkPi microservice using the https://www.python.org[Python language] and the http://flask.pocoo.org[Flask framework].
 
-You should already have the necessary prerequisites installed and configured, but if not please review the link:/applications/my-first-radanalytics-app[instructions].
+You should already have the necessary prerequisites installed and configured, but if not please review the link:/my-first-radanalytics-app.html[instructions].
 
 == Create the application source file
 


### PR DESCRIPTION
The link back to the instructions was based on a previous version of the
site layout. This change corrects that.