### PR TITLE
update spark version in spring tutorial

### DIFF
--- a/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
@@ -460,6 +460,7 @@ The last piece of our project is the build file. If you are familiar with Java a
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <java.version>1.8</java.version>
+      <spark.version>2.3.0</spark.version>
    </properties>
    <dependencies>
       <dependency>
@@ -485,7 +486,7 @@ The last piece of our project is the build file. If you are familiar with Java a
       <dependency>
          <groupId>org.apache.spark</groupId>
          <artifactId>spark-core_2.11</artifactId>
-         <version>2.2.0</version>
+         <version>${spark.version}</version>
          <type>jar</type>
       </dependency>
    </dependencies>


### PR DESCRIPTION
This updates the spark version to 2.3.0 in the spring sparkpi tutorial
to match the current version of oshinko spark tooling.