### PR TITLE
Additional metadata for community presentations

### DIFF
--- a/_presentations/probabilistic-structures.adoc
+++ b/_presentations/probabilistic-structures.adoc
@@ -2,7 +2,10 @@
 :page-presentor: William Benton
 :page-date: 2018-01-26
 :page-media-url: https://youtu.be/4Kp35PjMHC8?t=6m28s
-:page-slides-url: https://chapeau.freevariable.com/2018/01/structures.html
+:page-slides-url: https://chapeau.freevariable.com/static/201801/probabilistic-structures.pdf
+:page-handout-url: https://chapeau.freevariable.com/2018/01/structures.html
+:page-venue: DevConf.cz
+:page-city: Brno, Czechia
 
 In this talk you'll learn about streaming algorithms and approximate data structures to characterize data sources that are too big to keep around or difficult to replay. We'll start simple, with an algorithm for on-line mean and variance estimates of a stream of samples. Then we'll look at Bloom filters (for approximate set membership), count-min sketch (for approximate member count in a multiset), and HyperLogLog (for approximate set cardinality). We'll cover implementing these algorithms, using them for data analysis (and even machine learning), and provide some intuition for why they work at scale. Come with reading knowledge of Python and leave with some cool new options in your scalable data processing toolbox!
 

--- a/_templates/presentation.adoc
+++ b/_templates/presentation.adoc
@@ -3,6 +3,9 @@
 :page-date: YYYY-MM-DD when the presentation was given (required)
 :page-media-url: a url to the broadcast of the presentation (required)
 :page-slides-url: a url to the slides from the presentation (optional)
+:page-handout-url: a url to the handout from the presentation (optional)
+:page-venue: the name of the conference or presentation venue (optional)
+:page-city: the location where the presentation was given, including state (for the US), province (for Canada), or country (for everywhere else) (optional)
 
 The abstract of the presentation goes here. This is an AsciiDoc document and
 as such you may use the available markup syntax.

--- a/community.html
+++ b/community.html
@@ -55,7 +55,7 @@ and add it to the list!
                 <div class="list-group-item-heading">
                   <h2> {{ pres.title }}</h2>
                   <em>{{ pres.presentor }}</em><br/>
-                  <em>{{ pres.date | date: '%B %Y' }}</em>
+                  <em>{% if pres.venue %}{{ pres.venue }} • {% endif %}{% if pres.city %}{{pres.city}} • {% endif %}{{ pres.date | date: '%B %Y' }}</em>
                 </div>
               </div>
             </div>

--- a/community.html
+++ b/community.html
@@ -54,7 +54,8 @@ and add it to the list!
               <div class="list-view-pf-description">
                 <div class="list-group-item-heading">
                   <h2> {{ pres.title }}</h2>
-                  <em>{{ pres.presentor }}</em>
+                  <em>{{ pres.presentor }}</em><br/>
+                  <em>{{ pres.date | date: '%B %Y' }}</em>
                 </div>
               </div>
             </div>

--- a/community.html
+++ b/community.html
@@ -71,9 +71,16 @@ and add it to the list!
 
             {% if pres.slides-url %}
             <a href="{{ pres.slides-url }}">
-              <i class="fa fa-picture-o" aria-hiddent="true"></i>
+              <i class="fa fa-picture-o" aria-hidden="true"></i>
               &nbsp; Slide deck</a>
             {% endif %}
+            
+            {% if pres.handout-url %}
+            <a href="{{ pres.handout-url }}">
+              <i class="fas fa-map" aria-hidden="true"></i>
+              &nbsp; Handout</a>
+            {% endif %}
+              
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR publishes date information for all talks and adds additional optional presentation metadata to capture the presentation venue, the city it was held in, and any handout (in addition to slides).