### PR TITLE
fix error in how do i menu

### DIFF
--- a/_data/menu.yaml
+++ b/_data/menu.yaml
@@ -7,7 +7,7 @@ radanalyticsio:
     url: /my-first-radanalytics-app.html
   - title: Tutorials
     url: /tutorials
-  - title: How Do I?
+  - title: How do I?
     url: /how-do-i
   - title: Community
     url: /community


### PR DESCRIPTION
The menu title was incorrect and included an uppercase character that
was throwing off the detection script.