### PR TITLE
fix standard menu links

### DIFF
--- a/_includes/menu_radanalytics.html
+++ b/_includes/menu_radanalytics.html
@@ -1,10 +1,9 @@
 {% for item in site.data.menu.radanalyticsio %}
 {% if page.menu_entry == item.title %}
 <li class="active">
-  <a href="#">{{ item.title }}</a>
 {% else %}
 <li>
-  <a href="{{ item.url }}">{{ item.title }}</a>
 {% endif %}
+  <a href="{{ item.url }}">{{ item.title }}</a>
 </li>
 {% endfor %}


### PR DESCRIPTION
This change makes the menu links always point back to their full url.
Previously the "current" page would redirect to a blank url with the
intent of reducing a reload to the same page. This turned out to make
poor usability for the "how do i" links.