### PR TITLE
add updates to ophicleide manifest

### DIFF
--- a/_applications/ophicleide.adoc
+++ b/_applications/ophicleide.adoc
@@ -232,6 +232,8 @@ ophicleide-web component.
     apiVersion: v1
     metadata:
       name: ophicleide-web
+      labels:
+        app: ophicleide
     spec:
       ports:
         - protocol: TCP
@@ -240,10 +242,32 @@ ophicleide-web component.
       selector:
         name: ophicleide
 
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: ophicleide-headless
+      labels:
+        app: ophicleide
+    spec:
+      clusterIP: None
+      ports:
+      - name: driver-rpc-port
+        port: 7078
+        protocol: TCP
+        targetPort: 7078
+      - name: blockmanager
+        port: 7079
+        protocol: TCP
+        targetPort: 7079
+      selector:
+        name: ophicleide
+
   - kind: Route
     apiVersion: v1
     metadata:
       name: ophicleide-web
+      labels:
+        app: ophicleide
     spec:
       host: ${WEB_ROUTE_HOSTNAME}
       to:
@@ -254,6 +278,8 @@ ophicleide-web component.
     apiVersion: v1
     metadata:
       name: ophicleide
+      labels:
+        app: ophicleide
     spec:
       strategy:
         type: Rolling
@@ -281,7 +307,7 @@ ophicleide-web component.
       template:
         metadata:
           labels:
-            name: ophicleide
+            app: ophicleide
         spec:
           containers:
             - name: ophicleide-web
@@ -303,8 +329,14 @@ ophicleide-web component.
                   value: ${MONGO}
                 - name: OPH_SPARK_MASTER_URL
                   value: ${SPARK}
+                - name: DRIVER_HOST
+                  value: ophicleide-headless
               ports:
                 - containerPort: 8080
+                  protocol: TCP
+                - containerPort: 7078
+                  protocol: TCP
+                - containerPort: 7079
                   protocol: TCP
 
   parameters:

--- a/assets/ophicleide/ophicleide-setup-list.yaml
+++ b/assets/ophicleide/ophicleide-setup-list.yaml
@@ -138,6 +138,7 @@ items:
       template:
         metadata:
           labels:
+            name: ophicleide
             app: ophicleide
         spec:
           containers:

--- a/assets/ophicleide/ophicleide-setup-list.yaml
+++ b/assets/ophicleide/ophicleide-setup-list.yaml
@@ -63,6 +63,8 @@ items:
     apiVersion: v1
     metadata:
       name: ophicleide-web
+      labels:
+        app: ophicleide
     spec:
       ports:
         - protocol: TCP
@@ -71,10 +73,32 @@ items:
       selector:
         name: ophicleide
 
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: ophicleide-headless
+      labels:
+        app: ophicleide
+    spec:
+      clusterIP: None
+      ports:
+      - name: driver-rpc-port
+        port: 7078
+        protocol: TCP
+        targetPort: 7078
+      - name: blockmanager
+        port: 7079
+        protocol: TCP
+        targetPort: 7079
+      selector:
+        name: ophicleide
+
   - kind: Route
     apiVersion: v1
     metadata:
       name: ophicleide-web
+      labels:
+        app: ophicleide
     spec:
       host: ${WEB_ROUTE_HOSTNAME}
       to:
@@ -85,6 +109,8 @@ items:
     apiVersion: v1
     metadata:
       name: ophicleide
+      labels:
+        app: ophicleide
     spec:
       strategy:
         type: Rolling
@@ -112,7 +138,7 @@ items:
       template:
         metadata:
           labels:
-            name: ophicleide
+            app: ophicleide
         spec:
           containers:
             - name: ophicleide-web
@@ -134,8 +160,14 @@ items:
                   value: ${MONGO}
                 - name: OPH_SPARK_MASTER_URL
                   value: ${SPARK}
+                - name: DRIVER_HOST
+                  value: ophicleide-headless
               ports:
                 - containerPort: 8080
+                  protocol: TCP
+                - containerPort: 7078
+                  protocol: TCP
+                - containerPort: 7079
                   protocol: TCP
 
   parameters:


### PR DESCRIPTION
With the change to spark 2.3+, the ophicleide application is having
issues connecting to an external spark cluster. This change will add the
necessary bits for the spark workers to communicate back to the master.
Additionally, an update was made to the ophicleide-training service to
support the new environment variable.