### PR TITLE
Changes to have the oc-proxy container use the same image as the webui.

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -964,8 +964,10 @@ items:
                     timeoutSeconds: 1
                     initialDelaySeconds: 20
                 - name: oc-proxy
-                  image: radanalyticsio/oc-proxy:stable
+                  image: ${OSHINKO_WEB_IMAGE}
                   imagePullPolicy: IfNotPresent
+                  command:
+                    - "/usr/src/app/oc"
                   args:
                     - proxy
                     - "-p"
@@ -1105,8 +1107,10 @@ items:
                     timeoutSeconds: 1
                     initialDelaySeconds: 20
                 - name: oc-proxy
-                  image: radanalyticsio/oc-proxy:stable
+                  image: ${OSHINKO_WEB_IMAGE}
                   imagePullPolicy: IfNotPresent
+                  command:
+                    - "/usr/src/app/oc"
                   args:
                     - proxy
                     - "-p"


### PR DESCRIPTION
The only difference is the command issued at start time.  After this change, we will no longer need to maintain a separate image for the oc-proxy container.