### PR TITLE
remove cluster name from winemap install

### DIFF
--- a/_applications/wine-map.adoc
+++ b/_applications/wine-map.adoc
@@ -75,7 +75,6 @@ oc new-app --template=oshinko-python-spark-build-dc \
   -p APPLICATION_NAME=winemap \
   -p GIT_URI=https://github.com/radanalyticsio/winemap.git \
   -p SPARK_OPTIONS='--packages org.postgresql:postgresql:42.1.4' \
-  -p OSHINKO_CLUSTER_NAME=<oshinko_cluster_name> \
   -e SERVER=postgresql \
   -e DBNAME=wineDb \
   -e PASSWORD=password \


### PR DESCRIPTION
This change removes the `OSHINKO_CLUSTER_NAME` parameter from the
winemap tutorial. This parameter is not mentioned in the instructions
and is not needed for the s2i deployment of the application.