### PR TITLE
move my first application into tutorials page

### DIFF
--- a/_data/menu.yaml
+++ b/_data/menu.yaml
@@ -3,8 +3,6 @@ radanalyticsio:
     url: /
   - title: Get Started
     url: /get-started
-  - title: My First App
-    url: /my-first-radanalytics-app.html
   - title: Tutorials
     url: /tutorials
   - title: How do I?

--- a/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-java-spring.adoc
@@ -1,4 +1,5 @@
 = SparkPi Java Spring
+:page-project-name: SparkPi
 :page-layout: markdown
 :page-menu_template: menu_tutorial_application.html
 :page-menu_backurl: /my-first-radanalytics-app.html

--- a/assets/my-first-radanalytics-app/sparkpi-java-vertx.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-java-vertx.adoc
@@ -1,4 +1,5 @@
 = SparkPi Java Vert.x
+:page-project-name: SparkPi
 :page-layout: markdown
 :page-menu_template: menu_tutorial_application.html
 :page-menu_backurl: /my-first-radanalytics-app.html

--- a/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
+++ b/assets/my-first-radanalytics-app/sparkpi-python-flask.adoc
@@ -1,4 +1,5 @@
 = SparkPi Python Flask
+:page-project-name: SparkPi
 :page-layout: markdown
 :page-menu_template: menu_tutorial_application.html
 :page-menu_backurl: /my-first-radanalytics-app.html

--- a/my-first-radanalytics-app.adoc
+++ b/my-first-radanalytics-app.adoc
@@ -1,10 +1,10 @@
-= My First RADanalytics Application
+= SparkPi, your first Apache Spark application with radanalytics.io
 :page-link: my-first-radanalytics-app
 :page-layout: markdown
 :page-menu_entry: My First App
 :page-description: In this tutorial you will learn how to create a source-to-image application for Apache Spark from the ground up. The source code is based on the upstream Pi calculator from the Apache Spark project examples with a slight twist, the addition of a web server to create an on-demand calculation microservice.
 
-pass:[<h1>My First RADanalytics Application</h1>]
+pass:[<h1>SparkPi, your first Apache Spark application with radanalytics.io</h1>]
 
 [[introduction]]
 == Introduction

--- a/my-first-radanalytics-app.adoc
+++ b/my-first-radanalytics-app.adoc
@@ -1,10 +1,10 @@
-= SparkPi, your first Apache Spark application with radanalytics.io
+= SparkPi: an introduction to applications using Apache Spark with radanalytics.io
 :page-link: my-first-radanalytics-app
 :page-layout: markdown
 :page-menu_entry: My First App
 :page-description: In this tutorial you will learn how to create a source-to-image application for Apache Spark from the ground up. The source code is based on the upstream Pi calculator from the Apache Spark project examples with a slight twist, the addition of a web server to create an on-demand calculation microservice.
 
-pass:[<h1>SparkPi, your first Apache Spark application with radanalytics.io</h1>]
+pass:[<h1>SparkPi: an introduction to applications using Apache Spark with radanalytics.io</h1>]
 
 [[introduction]]
 == Introduction

--- a/tutorials.md
+++ b/tutorials.md
@@ -29,6 +29,28 @@ them to your peers and colleagues.
 
 <h1 id="applications">Applications</h1>
 
+<h2>
+<a href="/my-first-radanalytics-app.html">SparkPi, your first Apache Spark application with radanalytics.io</a>
+</h2>
+<h4>
+<span class="badge">Java</span>
+<span class="badge">Python</span>
+</h4>
+
+<p>In this tutorial you will build a microservice which will calculate an
+approximate value for Pi when requested by HTTP. You will learn how to create
+applications which utilize Apache Spark and that are deployed directly from a
+source repository to OpenShift with a single command.</p>
+
+#### Project Links
+
+<ul>
+<li><a href="https://github.com/radanalyticsio/tutorial-sparkpi-java-spring" target="blank">https://github.com/radanalyticsio/tutorial-sparkpi-java-spring</a></li>
+<li><a href="https://github.com/radanalyticsio/tutorial-sparkpi-java-vertx" target="blank">https://github.com/radanalyticsio/tutorial-sparkpi-java-vertx</a></li>
+<li><a href="https://github.com/radanalyticsio/tutorial-sparkpi-python-flask" target="blank">https://github.com/radanalyticsio/tutorial-sparkpi-python-flask</a></li>
+</ul>
+<br/>
+
 {% assign sorted_applications = site.applications | sort: 'weight' %}
 {% for item in sorted_applications %}
 <h2>

--- a/tutorials.md
+++ b/tutorials.md
@@ -30,7 +30,7 @@ them to your peers and colleagues.
 <h1 id="applications">Applications</h1>
 
 <h2>
-<a href="/my-first-radanalytics-app.html">SparkPi, your first Apache Spark application with radanalytics.io</a>
+<a href="/my-first-radanalytics-app.html">SparkPi: an introduction to applications using Apache Spark with radanalytics.io</a>
 </h2>
 <h4>
 <span class="badge">Java</span>


### PR DESCRIPTION
This change is moving the my first application tutorial to make it more
consistent with the other tutorial content on the site. It has been
observed that even experienced users miss the navbar entry for this
tutorial.

changes
* remove my first app from menu
* change titles in my first app to read better
* add project titles to sparkpi impl docs