### PR TITLE
add article on deploying spark with oshinko cli

### DIFF
--- a/_howdoi/deploy-a-spark-cluster-cli.adoc
+++ b/_howdoi/deploy-a-spark-cluster-cli.adoc
@@ -21,10 +21,25 @@ name for the new cluster.
 .Procedure
 
 . Type `oshinko create <cluster name>` into your terminal shell, replacing
-  `<cluster name>` with the name you will use to identify the cluster.
+  `<cluster name>` with the name you will use to identify the cluster. It
+  will look similar to this:
++
+....
+$ oshinko create mycluster
+shared cluster mycluster created
+spark master: spark://mycluster:7077
+....
 
 . Confirm your cluster is created by typing `oshinko get <cluster name>`,
-  replacing `<cluster name>` with the name you chose for the cluster.
+  replacing `<cluster name>` with the name you chose for the cluster. It will
+  look similar to this:
++
+....
+$ oshinko get mycluster
+
+name                     workers                 status
+mycluster                1                       Running
+....
 
 .Additional resources
 

--- a/_howdoi/deploy-a-spark-cluster-cli.adoc
+++ b/_howdoi/deploy-a-spark-cluster-cli.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+[id='deploy-a-spark-cluster-cli']
+= deploy an Apache Spark cluster with the Oshinko command line interface tool?
+:page-layout: howdoi
+:page-menu_entry: How do I?
+
+Deploying an Apache Spark cluster through the Oshinko command line interface
+tool is a simple process that in most cases can be done by providing only a
+name for the new cluster.
+
+.Prerequisites
+
+* A terminal shell and OpenShift `oc` tool available with an active login to
+  OpenShift.
+
+* An OpenShift project with the radanalytics.io manifest installed, see the
+  link:/get-started[Get Started] instructions for more help.
+
+.Procedure
+
+. Type `oshinko create <cluster name>` into your terminal shell, replacing
+  `<cluster name>` with the name you will use to identify the cluster.
+
+. Confirm your cluster is created by typing `oshinko get <cluster name>`,
+  replacing `<cluster name>` with the name you chose for the cluster.
+
+.Additional resources
+
+* link:/howdoi/install-oshinko-cli[How do I install the Oshinko command line interface tool?]

--- a/_howdoi/install-oshinko-cli.adoc
+++ b/_howdoi/install-oshinko-cli.adoc
@@ -2,7 +2,7 @@
 //
 // <List assemblies here, each on a new line>
 [id='install-oshinko-cli']
-= install the Oshinko command line interface tool
+= install the Oshinko command line interface tool?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 
@@ -24,3 +24,5 @@ another option for creating and managing Apache Spark clusters on OpenShift.
 .Additional resources
 
 * link:https://github.com/radanalyticsio/oshinko-cli[Oshinko CLI project repository]
+
+* link:/howdoi/deploy-a-spark-cluster-cli[How do I deploy an Apache Spark cluster with the Oshinko command line interface tool?]


### PR DESCRIPTION
This change adds the new how do i article for deploying a cluster with
oshinko-cli. It also updates links and the title of the oshinko-cli
install how do i article.