### PR TITLE
fix titles in how do i articles

### DIFF
--- a/_howdoi/access-advanced-config-oshinko-webui.adoc
+++ b/_howdoi/access-advanced-config-oshinko-webui.adoc
@@ -2,7 +2,7 @@
 //
 // <List assemblies here, each on a new line>
 [id='access-advanced-config-oshinko-webui']
-= access advanced cluster configurations in the Oshinko WebUI?
+= How do I access advanced cluster configurations in the Oshinko WebUI?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/access-spark-webui.adoc
+++ b/_howdoi/access-spark-webui.adoc
@@ -2,7 +2,7 @@
 //
 // <List assemblies here, each on a new line>
 [id='access-spark-webui']
-= access the Apache Spark web interface?
+= How do I access the Apache Spark web interface?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/connect-to-cluster.adoc
+++ b/_howdoi/connect-to-cluster.adoc
@@ -1,4 +1,4 @@
-= connect to a cluster to debug / develop?
+= How do I connect to a cluster to debug / develop?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/connect-to-kafka.adoc
+++ b/_howdoi/connect-to-kafka.adoc
@@ -1,4 +1,4 @@
-= connect to Apache Kafka?
+= How do I connect to Apache Kafka?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/deploy-a-spark-cluster-cli.adoc
+++ b/_howdoi/deploy-a-spark-cluster-cli.adoc
@@ -2,7 +2,7 @@
 //
 // <List assemblies here, each on a new line>
 [id='deploy-a-spark-cluster-cli']
-= deploy an Apache Spark cluster with the Oshinko command line interface tool?
+= How do I deploy an Apache Spark cluster with the Oshinko command line interface tool?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/deploy-a-spark-cluster-webui.adoc
+++ b/_howdoi/deploy-a-spark-cluster-webui.adoc
@@ -2,7 +2,7 @@
 //
 // <List assemblies here, each on a new line>
 [id='deploy-a-spark-cluster-webui']
-= deploy an Apache Spark cluster with the Oshinko WebUI?
+= How do I deploy an Apache Spark cluster with the Oshinko WebUI?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/install-oshinko-cli.adoc
+++ b/_howdoi/install-oshinko-cli.adoc
@@ -2,7 +2,7 @@
 //
 // <List assemblies here, each on a new line>
 [id='install-oshinko-cli']
-= install the Oshinko command line interface tool?
+= How do I install the Oshinko command line interface tool?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/launch-jupyter-notebook.adoc
+++ b/_howdoi/launch-jupyter-notebook.adoc
@@ -1,4 +1,4 @@
-= launch a Jupyter notebook on OpenShift?
+= How do I launch a Jupyter notebook on OpenShift?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/recognize-version-clash.adoc
+++ b/_howdoi/recognize-version-clash.adoc
@@ -1,4 +1,4 @@
-= recognize Spark version mismatch between driver, master and/or workers?
+= How do I recognize Spark version mismatch between driver, master and/or workers?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/use-python-packages.adoc
+++ b/_howdoi/use-python-packages.adoc
@@ -1,4 +1,4 @@
-= install Python packages in Jupyter notebooks on OpenShift?
+= How do I install Python packages in Jupyter notebooks on OpenShift?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 :source-highlighter: coderay

--- a/_howdoi/use-python3-with-spark.adoc
+++ b/_howdoi/use-python3-with-spark.adoc
@@ -1,4 +1,4 @@
-= use Python 3 with Apache Spark?
+= How do I use Python 3 with Apache Spark?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/use-spark-configs.adoc
+++ b/_howdoi/use-spark-configs.adoc
@@ -1,4 +1,4 @@
-= use custom Spark configuration files with my cluster?
+= How do I use custom Spark configuration files with my cluster?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_howdoi/validate-radanalytics-install.adoc
+++ b/_howdoi/validate-radanalytics-install.adoc
@@ -1,4 +1,4 @@
-= validate my radanalytics.io installation?
+= How do I validate my radanalytics.io installation?
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/_layouts/howdoi.html
+++ b/_layouts/howdoi.html
@@ -5,7 +5,7 @@ layout: default
 <div class="container-fluid">
   <div class="row">
     <div class="col-lg-10 col-lg-offset-1">
-      <h1>How do I {{ page.title }}</h1>
+      <h1>{{ page.title }}</h1>
     </div>
   </div>
   <div class="row margin-top-1">

--- a/_templates/how-do-i.adoc
+++ b/_templates/how-do-i.adoc
@@ -1,4 +1,4 @@
-= This is the title, it should not include "how do i"
+= This is the title, it should start with "How do I"
 :page-layout: howdoi
 :page-menu_entry: How do I?
 

--- a/how-do-i.html
+++ b/how-do-i.html
@@ -25,7 +25,7 @@ menu_entry: How do I?
           <div class="list-view-pf-body">
             <div class="list-view-pf-description">
               <div class="list-group-item-heading">
-                <h4>{{ doc.title }}</h4>
+                <h4>{{ doc.title | remove_first: "How do I " }}</h4>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Previously, the how do i articles all assumed that a writer would create
a title that did not include the "How do I" preamble. This resulted in
document titles that looked incomplete and poorly formed. This change
makes it so that the individual article titles must include the full
sentence including "How do I" at the beginning.