### PR TITLE
update menu for sparkpi main page

### DIFF
--- a/my-first-radanalytics-app.adoc
+++ b/my-first-radanalytics-app.adoc
@@ -2,6 +2,8 @@
 :page-link: my-first-radanalytics-app
 :page-layout: markdown
 :page-menu_entry: My First App
+:page-menu_template: menu_tutorial_application.html
+:page-project-name: SparkPi
 :page-description: In this tutorial you will learn how to create a source-to-image application for Apache Spark from the ground up. The source code is based on the upstream Pi calculator from the Apache Spark project examples with a slight twist, the addition of a web server to create an on-demand calculation microservice.
 
 pass:[<h1>SparkPi: an introduction to applications using Apache Spark with radanalytics.io</h1>]


### PR DESCRIPTION
The menu entry was not updated to reflect the current location in the
tutorials page. This change makes the sparkpi top-level document conform
to the other tutorials.