### PR TITLE
add scala badge to sparkpi description

### DIFF
--- a/tutorials.md
+++ b/tutorials.md
@@ -35,6 +35,7 @@ them to your peers and colleagues.
 <h4>
 <span class="badge">Java</span>
 <span class="badge">Python</span>
+<span class="badge">Scala</span>
 </h4>
 
 <p>In this tutorial you will build a microservice which will calculate an


### PR DESCRIPTION
the entry on the tutorials page is missing this label.