### PR TITLE
update jekyll version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ ruby RUBY_VERSION
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 #
-gem "jekyll", "3.5.1"
+gem "jekyll", "~> 3.6.3"
 gem "coderay", "~> 1.1.2"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,16 +8,16 @@ GEM
     colorator (1.1.0)
     ffi (1.9.25)
     forwardable-extended (2.6.0)
-    jekyll (3.5.1)
+    jekyll (3.6.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
-      kramdown (~> 1.3)
+      kramdown (~> 1.14)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (~> 1.7)
+      rouge (>= 1.7, < 3)
       safe_yaml (~> 1.0)
     jekyll-asciidoc (2.1.0)
       asciidoctor (>= 1.5.0)
@@ -28,7 +28,7 @@ GEM
       listen (~> 3.0)
     json (2.1.0)
     kramdown (1.17.0)
-    liquid (4.0.0)
+    liquid (4.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -40,10 +40,10 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rouge (1.11.1)
+    rouge (2.2.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.7)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -54,7 +54,7 @@ PLATFORMS
 
 DEPENDENCIES
   coderay (~> 1.1.2)
-  jekyll (= 3.5.1)
+  jekyll (~> 3.6.3)
   jekyll-asciidoc
   json
 
@@ -63,4 +63,3 @@ RUBY VERSION
 
 BUNDLED WITH
    1.16.1
-


### PR DESCRIPTION
This is in response to a warning from github about the jekyll version.
It has been updated and the gemfile.lock regenerated.