### PR TITLE
remove oc command from get started

### DIFF
--- a/get-started.adoc
+++ b/get-started.adoc
@@ -23,12 +23,6 @@ Looking for the shortest path to begin working with
 radanalytics.io? Please see the
 link:/howdoi/install-radanalyticsio[How do I install radanalytics.io?]
 article.
-
-For very quick start you may want to use this command:
-....
-oc create -f https://radanalytics.io/resources.yaml
-....
-
 ****
 
 == Which projects should you start with?


### PR DESCRIPTION
The instructional commands should be contained in our "how do i"
documents. This allows us the the maximum re-use of the modular doc
format and also reduces the number of places we need to maintain when
updating instructions.