### PR TITLE
add multiple media links for presentations

### DIFF
--- a/_templates/presentation.adoc
+++ b/_templates/presentation.adoc
@@ -1,7 +1,7 @@
 = Title of the presentation goes here
 :page-presentor: put the presentors here (required)
 :page-date: YYYY-MM-DD when the presentation was given (required)
-:page-media-url: a url to the broadcast of the presentation (required)
+:page-media-url: ["https://your-presentation.com/", "https://an-alternate-link.com"] this can be a list of links or a single link for your presentation media (required)
 :page-slides-url: a url to the slides from the presentation (optional)
 :page-handout-url: a url to the handout from the presentation (optional)
 :page-venue: the name of the conference or presentation venue (optional)

--- a/community.html
+++ b/community.html
@@ -28,7 +28,7 @@ solutions for your own data driven applications.
       <p>
 The following presentations are about the technologies involved in and
 related to the radanalytics.io projects. We love our community and the
-passion they have for these technologies. If you know of a presentation 
+passion they have for these technologies. If you know of a presentation
 that would fit in here, please open a
 <a href="https://github.com/radanalyticsio/radanalyticsio.github.io/pulls">pull request</a>
 and add it to the list!
@@ -72,25 +72,26 @@ and add it to the list!
         <div class="list-group-item-container container-fluid hidden">
           <div>
             <p><em>{% if pres.venue %}{{ pres.venue }} • {% endif %}{% if pres.city %}{{pres.city}} • {% endif %}{{ pres.date | date: '%B %Y' }}</em></p>
-            
-            {{ pres.content }}
 
-            <a href="{{ pres.media-url }}">
+            {{ pres.content }}
+            {% for murl in pres.media-url %}
+            <a href="{{ murl }}">
               <i class="fa fa-video-camera" aria-hidden="true"></i>
-              &nbsp; Presentation media</a>
+              &nbsp; Presentation media</a>&nbsp;
+            {% endfor %}
 
             {% if pres.slides-url %}
             <a href="{{ pres.slides-url }}">
               <i class="fa fa-picture-o" aria-hidden="true"></i>
-              &nbsp; Slide deck</a>
+              &nbsp; Slide deck</a>&nbsp;
             {% endif %}
-            
+
             {% if pres.handout-url %}
             <a href="{{ pres.handout-url }}">
               <i class="fa fa-map" aria-hidden="true"></i>
               &nbsp; Handout</a>
             {% endif %}
-              
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
This change adds the feature for having multiple presentation urls in a
presentation entry.

changes
* update community template to process multiple urls
* update community template to add some spacing between links
* update all presentations with new link format
* update presentation template