### PR TITLE
adds local PDF of slide deck for eje/willb SAIS EU talk

### DIFF
--- a/_presentations/spark-for-library-developers-sseu-2018-part-1.adoc
+++ b/_presentations/spark-for-library-developers-sseu-2018-part-1.adoc
@@ -2,7 +2,7 @@
 :page-presentor: Erik Erlandson & Will Benton
 :page-date: 2018-10-03
 :page-media-url: https://youtu.be/Bh0LlrWs6Fk
-:page-slides-url: https://www.slideshare.net/databricks/apache-spark-for-library-developers-with-erik-erlandson-and-william-benton
+:page-slides-url: /assets/spark-for-library-developers/spark-for-library-developers.pdf 
 :page-venue: Spark+AI Summit EU
 :page-city: London, England
 

--- a/_presentations/spark-for-library-developers-sseu-2018-part-2.adoc
+++ b/_presentations/spark-for-library-developers-sseu-2018-part-2.adoc
@@ -2,7 +2,8 @@
 :page-presentor: Erik Erlandson & Will Benton
 :page-date: 2018-10-03
 :page-media-url: https://youtu.be/PO4Voe9u_Fo
-:page-slides-url: https://www.slideshare.net/databricks/apache-spark-for-library-developers-with-erik-erlandson-and-william-benton
+:page-slides-url: /assets/spark-for-library-developers/spark-for-library-developers.pdf 
+
 :page-venue: Spark+AI Summit EU
 :page-city: London, England
 


### PR DESCRIPTION
This adds a local PDF of the slides for "Apache Spark for Library Developers."

Fixes #285.