### PR TITLE
Update resources.yaml for spark 2.4

### DIFF
--- a/_data/spark.yaml
+++ b/_data/spark.yaml
@@ -1,1 +1,1 @@
-version: 2.3.0
+version: 2.4.0

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -27,11 +27,15 @@ NEW_TAG=v9.9.9
 wget $RESOURCES_URL -qO - \
 | sed -r -e "s@(radanalyticsio/.*:)($DEFAULT_TAG)@\1$NEW_TAG@" | oc create -f -
 ```
-
 https://radanalytics.io/resources.yaml  
 This is the latest resources file from [radanalytics.io](https://radanalytics.io)  
 DEFAULT_TAG=stable  
-NEW_TAG may be any version newer than v0.5.3
+NEW_TAG may be any version v0.6.1 or newer
+
+https://radanalytics.io/openshift/resources-v0.5.6.yaml
+This file supports versions v0.5.4 and v0.5.6 of Oshinko
+DEFAULT_TAG=v0.5.6
+NEW_TAG may be v0.5.4 or v0.5.6
 
 https://radanalytics.io/openshift/resources-v0.5.3.yaml  
 This file supports versions v0.4.x and v0.5.x of Oshinko  

--- a/openshift/resources-v0.5.6.yaml
+++ b/openshift/resources-v0.5.6.yaml
@@ -26,14 +26,14 @@ items:
     metadata:
       name: oshinko-py36-conf
     data:
-      sparkimage: openshift-spark-py36:2.4-latest
+      sparkimage: openshift-spark-py36:2.3-latest
 
   - apiVersion: v1
     kind: ConfigMap
     metadata:
       name: default-oshinko-cluster-config
     data:
-      sparkimage: openshift-spark:2.4-latest
+      sparkimage: openshift-spark:2.3-latest
 
   - apiVersion: v1
     kind: ImageStream
@@ -48,9 +48,9 @@ items:
       - annotations: null
         from:
           kind: DockerImage
-          name: radanalyticsio/radanalytics-pyspark:stable
+          name: radanalyticsio/radanalytics-pyspark:v0.5.6
         importPolicy: {}
-        name: stable
+        name: v0.5.6
         referencePolicy:
           type: Source
 
@@ -67,9 +67,9 @@ items:
       - annotations: null
         from:
           kind: DockerImage
-          name: radanalyticsio/radanalytics-pyspark-py36:stable
+          name: radanalyticsio/radanalytics-pyspark-py36:v0.5.6
         importPolicy: {}
-        name: stable
+        name: v0.5.6
         referencePolicy:
           type: Source
 
@@ -86,9 +86,9 @@ items:
       - annotations: null
         from:
           kind: DockerImage
-          name: radanalyticsio/radanalytics-java-spark:stable
+          name: radanalyticsio/radanalytics-java-spark:v0.5.6
         importPolicy: {}
-        name: stable
+        name: v0.5.6
         referencePolicy:
           type: Source
 
@@ -105,9 +105,9 @@ items:
       - annotations: null
         from:
           kind: DockerImage
-          name: radanalyticsio/radanalytics-scala-spark:stable
+          name: radanalyticsio/radanalytics-scala-spark:v0.5.6
         importPolicy: {}
-        name: stable
+        name: v0.5.6
         referencePolicy:
           type: Source
 
@@ -124,9 +124,9 @@ items:
       - annotations: null
         from:
           kind: DockerImage
-          name: radanalyticsio/openshift-spark:2.4-latest
+          name: radanalyticsio/openshift-spark:2.3-latest
         importPolicy: {}
-        name: 2.4-latest
+        name: 2.3-latest
         referencePolicy:
           type: Source
 
@@ -143,9 +143,9 @@ items:
       - annotations: null
         from:
           kind: DockerImage
-          name: radanalyticsio/openshift-spark-py36:2.4-latest
+          name: radanalyticsio/openshift-spark-py36:2.3-latest
         importPolicy: {}
-        name: 2.4-latest
+        name: 2.3-latest
         referencePolicy:
           type: Source
 
@@ -194,7 +194,7 @@ items:
               value: ${APP_FILE}
             from:
               kind: ImageStreamTag
-              name: radanalytics-pyspark:stable
+              name: radanalytics-pyspark:v0.5.6
           type: Source
         triggers:
         - imageChange: {}
@@ -385,7 +385,7 @@ items:
               value: ${APP_FILE}
             from:
               kind: ImageStreamTag
-              name: radanalytics-pyspark-py36:stable
+              name: radanalytics-pyspark-py36:v0.5.6
           type: Source
         triggers:
         - imageChange: {}
@@ -577,7 +577,7 @@ items:
               value: ${APP_FILE}
             from:
               kind: ImageStreamTag
-              name: radanalytics-java-spark:stable
+              name: radanalytics-java-spark:v0.5.6
           type: Source
         triggers:
         - imageChange: {}
@@ -775,7 +775,7 @@ items:
               value: ${SBT_ARGS_APPEND}
             from:
               kind: ImageStreamTag
-              name: radanalytics-scala-spark:stable
+              name: radanalytics-scala-spark:v0.5.6
           type: Source
         triggers:
         - imageChange: {}
@@ -1116,7 +1116,7 @@ items:
       - name: OSHINKO_WEB_IMAGE
         description: Full name of the oshinko web image
         required: true
-        value: radanalyticsio/oshinko-webui:stable
+        value: radanalyticsio/oshinko-webui:v0.5.6
       - name: OSHINKO_WEB_ROUTE_HOSTNAME
         description: The hostname used to create the external route for the webui
       - name: OSHINKO_REFRESH_INTERVAL
@@ -1258,7 +1258,7 @@ items:
       - name: OSHINKO_WEB_IMAGE
         description: Full name of the oshinko web image
         required: true
-        value: radanalyticsio/oshinko-webui:stable
+        value: radanalyticsio/oshinko-webui:v0.5.6
       - name: OSHINKO_WEB_ROUTE_HOSTNAME
         description: The hostname used to create the external route for the webui
       - name: OSHINKO_REFRESH_INTERVAL


### PR DESCRIPTION
Because resources.yaml contains configmaps and imagestreams
for spark that align with major.minor versions, it needs to
be revved when we change the spark major or minor version.

This change archives the previous resources.yaml for v0.5.6
and updates the top-level resources.yaml to reference spark 2.4.