### PR TITLE
remove google analytics from website

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
   <head>
-    <script src="/js/radanalytics-analytics.js"></script>
-    <script async src="https://www.google-analytics.com/analytics.js"></script>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/js/radanalytics-analytics.js
+++ b/js/radanalytics-analytics.js
@@ -1,3 +1,0 @@
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', 'UA-94133700-1', 'auto');
-ga('send', 'pageview');


### PR DESCRIPTION
this change removes the links for google analytics tracking. it is being proposed because google universal analytics is going end of life on july 1 2023[0].

[0] https://support.google.com/analytics/answer/11583528?hl=en

i would like to propose removing the analytics links as opposed to upgrading to the new version unless there is a community member who would like to take over the responsibility of monitoring the traffic from google. the site has seen a large dropoff in traffic over the last year (down from >1000 unique hits per month to <20 unique hits per month).